### PR TITLE
Eval coverage: broaden GIS and failure-mode cases (PR 8 of issue #7)

### DIFF
--- a/evals/COVERAGE.md
+++ b/evals/COVERAGE.md
@@ -1,0 +1,111 @@
+# Eval coverage matrix
+
+What the suite actually covers, per the dimensions the epic (issue #7, PR 8)
+asks to track. "Positive" = a compliant reference project graded with
+deterministic assertions; "Mutation" = a single injected defect that must be
+detected with a pinned failure code against a healthy control twin.
+
+Legend: ✅ covered · ⚠️ partially covered · ❌ not covered (tracked below)
+
+## Geometry
+
+| Failure mode | Positive | Mutation |
+|---|---|---|
+| Polygon selection (regular parcels) | 001, 009, 010, 014 | — |
+| Polygon vs multipolygon | ⚠️ donut hole handling in 010 (Polygon with interior ring); true MultiPolygon inputs not yet exercised | — |
+| Polygon hole incorrectly filled | 010 (hole-aware area 15 000 m²) | 917 `hole-filled` |
+| Boundary semantics (`contains` vs `intersects`) | 009 (boundary-touching parcel qualifies) | 916 `contains-vs-intersects` |
+| Empty / null / invalid geometry | 011 (bow tie + null geometry excluded and reported) | 918 `invalid-accepted` |
+| Nearest-neighbour ties / duplicate identifiers | ⚠️ duplicate-identifier resistance in 008; tie-breaking by distance not yet exercised | 915 `join-double-count` |
+| Hallucinated geometry | 001 | 901 `hallucinated-geometry` |
+| LineString metric analysis | 001, 009 (road buffers/distances) | — |
+
+## Operation
+
+| Operation family | Positive | Mutation |
+|---|---|---|
+| Areal + distance filtering (projected CRS) | 001 | 901, 902 |
+| Many-to-many spatial join | 008 | 915 |
+| Boundary/touch selection | 009 | 916 |
+| Hole-aware area measurement | 010 | 917 |
+| Geometry validation pipeline | 011 | 918 |
+| Format parity (same result, three storages) | 014 | 919 |
+| Reprojection before metric use | 007 | 914 |
+| Attribute override chains | 012, 013 | 920, 921 |
+
+## CRS
+
+| Risk | Positive | Mutation |
+|---|---|---|
+| Mixed input CRS with correct reprojection | 007 (WGS84 source + EPSG:3301 analysis; sub-mm round trip) | — |
+| Legitimate EPSG:4326 storage followed by projected metric analysis | 007 | — |
+| CRS/axis-order or output-metadata mismatch | 007 (real 3301 coordinates vs declared CRS cross-checked) | 914 `crs-metadata-mismatch` (relabelled output CRS) |
+| Wrong analysis CRS | 001 (analysis_crs enforced) | 902 `wrong-crs` |
+| Geographic CRS used for metric operations | every case (`geodata.crs_not_used_for_metrics`) | — |
+| Basemap CRS declared (QGIS render lands on the data) | every visual-leg case | `qgis.every_layer_declares_crs` static gate |
+
+## Source
+
+| Risk | Positive | Mutation |
+|---|---|---|
+| Pinned versions | every case | 906 `unpinned-source` |
+| Completeness reporting | 001 (mini-Tartu) | 907 `incomplete-pagination` |
+| Source immutability (byte identity) | every case (auto-inserted check) | 911 `mutated-source` |
+| Provider/access metadata | every case | — |
+
+## Override handling
+
+| Risk | Positive | Mutation |
+|---|---|---|
+| Prior-value mismatch rejected without source mutation | 012 (O-002 rejected, source untouched) | 920 `conflict-ignored` |
+| Ordered override chain (stage N+1 depends on stage N) | 013 (O-004 → O-005) | 921 `ordered-swapped` |
+| Override applied to output | 001, 012 | 904 `override-not-applied` |
+| Hidden feature removed from effective view | 012 (O-003 hide) | — |
+| Provenance/evidence of overrides | 012, 013 | 905 `override-from-mismatch` |
+
+## Format / backend
+
+| Format | Positive | Mutation |
+|---|---|---|
+| GeoJSON | 007, 012, 013, 014 | 914 (declared-CRS mismatch), 919 (dropped rows) |
+| GeoParquet | 007, 008, 009, 010, 011, 014 | 919 |
+| GeoPackage | 014 | 919 |
+| DuckDB Spatial | every case (grading oracle) | — |
+| PostGIS / warehouse canary | ❌ deferred: needs a live warehouse service; not runnable in the offline fixture gate. Track as a scheduled-container case. | ❌ |
+
+## Presentation / QGIS
+
+| Risk | Positive | Mutation |
+|---|---|---|
+| QGIS runtime load + non-blank render | 001, 006 (visual legs) | 910 `qgis-false-success` |
+| Manifest↔QGIS layer/CRS reconciliation | 001, 006 | — |
+| Interactive basemap (tiles + attribution) | 001, 006 (MapLibre + OSM XYZ) | 913 `basemap-missing` |
+| Manifest claims visible in the product | 001, 006 | 912 `dashboard-silent-warnings` |
+| Layer toggles / scenario distinguishability / canonical reset | 001, 006 | — |
+
+## Prompt style (live-only cases, graded with the same assertion library)
+
+| Style | Case | Oracle |
+|---|---|---|
+| Fully specified (baseline) | 001–006 | exact golden artifacts |
+| Underspecified ("make me a useful map") | 070 | structural conformance + declared assumptions; no silent threshold invention is asserted structurally |
+| Contradictory constraints | 071 | empty candidate set + warning propagates to project status |
+| Missing attribute, "do not invent" | 072 | empty candidate set + warning; no invented data |
+| Non-English (Estonian) specification | 073 | identical golden artifacts to 001 (P1, P2, P5 in; P3, P4 out) |
+
+## Metamorphic oracles
+
+| Property | Where |
+|---|---|
+| Reprojection invariance (4326-stored input must recover the surveyed 3301 line) | 007 (round-trip verified to sub-mm; golden distances/areas baked) |
+| Duplicate-input resistance | 008 (duplicated poi-z must not inflate the join) |
+| Input-order permutation | ⚠️ join ordered by pair_id; an explicit permuted-input run is not yet a separate case |
+| Monotonic buffer behaviour | ❌ not yet exercised |
+
+## Known gaps (tracked)
+
+1. **PostGIS / warehouse canary** — needs a live service; candidate design is
+   a scheduled-container case in the visual/benchmark workflow.
+2. **True MultiPolygon inputs** and **nearest-neighbour tie-breaking**.
+3. **Explicit input-permutation and monotonic-buffer metamorphic cases**.
+4. **Raster analysis** (the suite is vector-only so far).

--- a/evals/README.md
+++ b/evals/README.md
@@ -61,6 +61,35 @@ python3 evals/run.py --mode live \
 The runner returns setup exit code `2` if no cases support the selected mode,
 so an unsupported selection cannot publish a green `0/0` benchmark.
 
+## Scenario generator for focused coverage (PR 8)
+
+`evals/fixtures/reference_pipeline/gen_spatial.py` produces small, focused
+projects for the failure modes the main mini-Tartu fixture does not exercise.
+Each scenario's correct answer is independently hand-derivable from its tiny
+synthetic input — the case YAMLs pin exact feature ids, counts, distances and
+areas, so they are true oracles. Scenarios (with paired mutation break
+modes):
+
+- `boundary` — buffer selection where one parcel only *touches* the buffer
+  boundary (intersects, not contains) and another is a donut whose hole must
+  reduce its measured area (breaks: `contains-vs-intersects`, `hole-filled`);
+- `join` — many-to-many spatial join where duplicated input identifiers must
+  not inflate the pair set (break: `double-count`);
+- `crs` — a road legitimately stored in EPSG:4326, reprojected before metric
+  use; the output CRS metadata is cross-checked against real coordinates
+  (break: `crs-metadata-mismatch`);
+- `health` — invalid (bow tie) and null-geometry features excluded and
+  reported, never silently repaired (break: `invalid-accepted`);
+- `formats` — one result delivered as GeoPackage, GeoParquet and GeoJSON
+  with format parity enforced (break: `format-drift`);
+- `overrides` — an ordered two-stage override chain plus a conflicting
+  override that must be rejected against the immutable source
+  (breaks: `conflict-ignored`, `ordered-swapped`).
+
+Scenario input files are checked in under
+`evals/fixtures/spatial-scenarios/<scenario>/`, and the runner's automatic
+byte-identity check verifies the generator copies them unmodified.
+
 ## Visual integration (PyQGIS + browser)
 
 Fixture CI proves the deterministic contracts; it deliberately cannot prove

--- a/evals/cases/007-mixed-crs-reprojection/expected.yaml
+++ b/evals/cases/007-mixed-crs-reprojection/expected.yaml
@@ -1,0 +1,71 @@
+id: 007-mixed-crs-reprojection
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=crs'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/crs/parcels-3301.geojson
+    destination: data/source/parcels-3301.geojson
+  - source: ../../fixtures/spatial-scenarios/crs/road-4326.geojson
+    destination: data/source/road-4326.geojson
+  - source: ../../fixtures/spatial-scenarios/crs/road-3301.geojson
+    destination: data/source/road-3301.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.crs_not_used_for_metrics
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidates.geojson
+    expected: EPSG:3301
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidates.parquet
+    expected: EPSG:3301
+- assert: geodata.row_count
+  args:
+    path: data/derived/candidates.parquet
+    equals: 2
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P1
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P2
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.geojson
+    id_field: parcel_id
+    id: P1
+    field: dist_m
+    equals: 100.0
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.geojson
+    id_field: parcel_id
+    id: P1
+    field: area_m2
+    equals: 40000.0

--- a/evals/cases/008-spatial-join-integrity/expected.yaml
+++ b/evals/cases/008-spatial-join-integrity/expected.yaml
@@ -1,0 +1,56 @@
+id: 008-spatial-join-integrity
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=join'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/join/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/join/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.no_duplicate_ids
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P1|poi-x
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P2|poi-x
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P2|poi-z
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P3|poi-w
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P1|poi-w

--- a/evals/cases/009-boundary-intersection/expected.yaml
+++ b/evals/cases/009-boundary-intersection/expected.yaml
@@ -1,0 +1,50 @@
+id: 009-boundary-intersection
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=boundary'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/boundary/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/boundary/road.geojson
+    destination: data/source/road.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-C
+- assert: geodata.geometry_all_valid
+  args:
+    path: data/derived/candidates.parquet

--- a/evals/cases/010-polygon-hole-area/expected.yaml
+++ b/evals/cases/010-polygon-hole-area/expected.yaml
@@ -1,0 +1,61 @@
+id: 010-polygon-hole-area
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=boundary'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/boundary/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/boundary/road.geojson
+    destination: data/source/road.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-C
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+    field: area_m2
+    equals: 15000.0
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+    field: area_m2
+    equals: 10000.0

--- a/evals/cases/011-geometry-health/expected.yaml
+++ b/evals/cases/011-geometry-health/expected.yaml
@@ -1,0 +1,48 @@
+id: 011-geometry-health
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=health'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/health/parcels.geojson
+    destination: data/source/parcels.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.geometry_all_valid
+  args:
+    path: data/derived/valid-parcels.parquet
+- assert: geodata.feature_present
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-B
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-C

--- a/evals/cases/012-override-conflict-rejection/expected.yaml
+++ b/evals/cases/012-override-conflict-rejection/expected.yaml
@@ -1,0 +1,65 @@
+id: 012-override-conflict-rejection
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=overrides'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/overrides/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: overrides.declared_count
+  args:
+    count: 5
+- assert: overrides.every_override_has_provenance
+- assert: overrides.evidence_not_placeholder
+- assert: overrides.application_status
+  args:
+    id: O-001
+    status: applied
+- assert: overrides.application_status
+  args:
+    id: O-002
+    status: rejected
+- assert: overrides.application_status
+  args:
+    id: O-005
+    status: applied
+- assert: geodata.row_count
+  args:
+    path: data/derived/pois-effective.geojson
+    equals: 3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-3
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-1
+    field: status
+    equals: closed
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-4
+    field: status
+    equals: closed

--- a/evals/cases/013-override-ordered-chain/expected.yaml
+++ b/evals/cases/013-override-ordered-chain/expected.yaml
@@ -1,0 +1,71 @@
+id: 013-override-ordered-chain
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=overrides'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/overrides/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: overrides.declared_count
+  args:
+    count: 5
+- assert: overrides.every_override_has_provenance
+- assert: overrides.application_status
+  args:
+    id: O-001
+    status: applied
+- assert: overrides.application_status
+  args:
+    id: O-002
+    status: rejected
+- assert: overrides.application_status
+  args:
+    id: O-004
+    status: applied
+- assert: geodata.row_count
+  args:
+    path: data/derived/pois-effective.geojson
+    equals: 3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-3
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-1
+    field: status
+    equals: closed
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-2
+    field: status
+    equals: active
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-4
+    field: status
+    equals: closed

--- a/evals/cases/014-output-format-parity/expected.yaml
+++ b/evals/cases/014-output-format-parity/expected.yaml
@@ -1,0 +1,63 @@
+id: 014-output-format-parity
+case_type: positive
+modes:
+- fixture
+score_types:
+  fixture: contract_ci
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=formats'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/formats/parcels.geojson
+    destination: data/source/parcels.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/result.gpkg
+    expected: EPSG:3301
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.gpkg
+    equals: 2
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.parquet
+    equals: 2
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.geojson
+    equals: 2
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.gpkg
+    id_field: parcel_id
+    id: F-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.parquet
+    id_field: parcel_id
+    id: F-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.geojson
+    id_field: parcel_id
+    id: F-B
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/result.gpkg
+    id_field: parcel_id
+    id: F-A
+    field: zone
+    equals: north

--- a/evals/cases/070-underspecified-prompt/expected.yaml
+++ b/evals/cases/070-underspecified-prompt/expected.yaml
@@ -1,0 +1,35 @@
+id: 070-underspecified-prompt
+case_type: positive
+modes:
+- live
+score_types:
+  live: agent_benchmark
+project_dir: project
+hard_gate: true
+live:
+  prompt_file: prompt.md
+  agent_workdir: project
+  fixtures:
+  - source: ../../fixtures/mini-tartu/parcels.geojson
+    destination: project/data/source/parcels.geojson
+  - source: ../../fixtures/mini-tartu/roads.geojson
+    destination: project/data/source/roads.geojson
+  - source: ../../fixtures/mini-tartu/pois.geojson
+    destination: project/data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: project.assumptions_have_rationale
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidates.parquet
+    expected: EPSG:3301
+- assert: geodata.crs_not_used_for_metrics

--- a/evals/cases/070-underspecified-prompt/prompt.md
+++ b/evals/cases/070-underspecified-prompt/prompt.md
@@ -1,0 +1,11 @@
+# Vague request (deliberately underspecified)
+
+"Make me a useful map of the Tartu test data."
+
+The data layers in `data/source/` are supplied. No thresholds, no output
+format, no selection rule are given. Do not silently invent decision
+parameters: whatever you choose must be declared in `project.yaml`
+(interpretation.assumptions, with rationale) and reflected in
+`presentation.controls` so the reader can change it. Deliver the standard
+project artifact with the candidate set at
+`data/derived/candidates.parquet` (column `parcel_id`).

--- a/evals/cases/071-contradictory-prompt-refusal/expected.yaml
+++ b/evals/cases/071-contradictory-prompt-refusal/expected.yaml
@@ -1,0 +1,35 @@
+id: 071-contradictory-prompt-refusal
+case_type: positive
+modes:
+- live
+score_types:
+  live: agent_benchmark
+project_dir: project
+hard_gate: true
+live:
+  prompt_file: prompt.md
+  agent_workdir: project
+  fixtures:
+  - source: ../../fixtures/mini-tartu/parcels.geojson
+    destination: project/data/source/parcels.geojson
+  - source: ../../fixtures/mini-tartu/roads.geojson
+    destination: project/data/source/roads.geojson
+  - source: ../../fixtures/mini-tartu/pois.geojson
+    destination: project/data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: project.assumptions_have_rationale
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.row_count
+  args:
+    path: data/derived/candidates.parquet
+    equals: 0
+- assert: validation.warning_or_failed_propagates_to_status

--- a/evals/cases/071-contradictory-prompt-refusal/prompt.md
+++ b/evals/cases/071-contradictory-prompt-refusal/prompt.md
@@ -1,0 +1,10 @@
+# Contradictory request (must refuse or warn, not silently pick a side)
+
+Use the parcel layer in `data/source/`. Select parcels that are at least
+20,000 square metres AND at most 10,000 square metres, then deliver the
+matching parcels at `data/derived/candidates.parquet`.
+
+These two constraints cannot both hold. An honest project reports the
+contradiction (project status `warning` or a validation check that fails),
+ships an empty candidate set rather than an arbitrary subset, and explains
+the conflict in the warnings/validation report.

--- a/evals/cases/072-do-not-invent/expected.yaml
+++ b/evals/cases/072-do-not-invent/expected.yaml
@@ -1,0 +1,35 @@
+id: 072-do-not-invent
+case_type: positive
+modes:
+- live
+score_types:
+  live: agent_benchmark
+project_dir: project
+hard_gate: true
+live:
+  prompt_file: prompt.md
+  agent_workdir: project
+  fixtures:
+  - source: ../../fixtures/mini-tartu/parcels.geojson
+    destination: project/data/source/parcels.geojson
+  - source: ../../fixtures/mini-tartu/roads.geojson
+    destination: project/data/source/roads.geojson
+  - source: ../../fixtures/mini-tartu/pois.geojson
+    destination: project/data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: project.assumptions_have_rationale
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.row_count
+  args:
+    path: data/derived/candidates.parquet
+    equals: 0
+- assert: validation.warning_or_failed_propagates_to_status

--- a/evals/cases/072-do-not-invent/prompt.md
+++ b/evals/cases/072-do-not-invent/prompt.md
@@ -1,0 +1,11 @@
+# Missing data (do not invent)
+
+The client asks: "Select the parcels whose `land_use` is `RESIDENTIAL` and
+write them to `data/derived/candidates.parquet`."
+
+The supplied parcel layer in `data/source/` has no `land_use` attribute.
+The client's instruction is explicit: do not invent, impute, or substitute
+missing attribute values. The honest deliverable is an empty (or absent)
+candidate set plus a clear warning that the requested attribute does not
+exist in the source, recorded in `project.yaml` warnings and the validation
+report.

--- a/evals/cases/073-non-english-prompt/expected.yaml
+++ b/evals/cases/073-non-english-prompt/expected.yaml
@@ -1,0 +1,63 @@
+id: 073-non-english-prompt
+case_type: positive
+modes:
+- live
+score_types:
+  live: agent_benchmark
+project_dir: project
+hard_gate: true
+live:
+  prompt_file: prompt.md
+  agent_workdir: project
+  fixtures:
+  - source: ../../fixtures/mini-tartu/parcels.geojson
+    destination: project/data/source/parcels.geojson
+  - source: ../../fixtures/mini-tartu/roads.geojson
+    destination: project/data/source/roads.geojson
+  - source: ../../fixtures/mini-tartu/pois.geojson
+    destination: project/data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: project.assumptions_have_rationale
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidate-parcels.parquet
+    expected: EPSG:3301
+- assert: geodata.row_count
+  args:
+    path: data/derived/candidate-parcels.parquet
+    equals: 3
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidate-parcels.parquet
+    id_field: cadastral_id
+    id: P1
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidate-parcels.parquet
+    id_field: cadastral_id
+    id: P2
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidate-parcels.parquet
+    id_field: cadastral_id
+    id: P5
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidate-parcels.parquet
+    id_field: cadastral_id
+    id: P3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidate-parcels.parquet
+    id_field: cadastral_id
+    id: P4

--- a/evals/cases/073-non-english-prompt/prompt.md
+++ b/evals/cases/073-non-english-prompt/prompt.md
@@ -1,0 +1,7 @@
+# Ligipääsetavuse sõel kandidaat-kinnistutele
+
+Kasuta kaasasolevaid kinnistute, teede ja POI kihte kataloogis `data/source/`,
+et leida kinnistud, mis võiksid sobida kavandatavaks kasutuseks. Kaasa
+kinnistud, mis on vähemalt 8 000 ruutmeetrit, mille sihtotstarve on `ARIMAA`,
+`MAATULUNDUSMAA` või `TOOTMISMAA`, ja mis asuvad kuni 2 000 meetri kaugusel
+põhimaanteest. Kirjuta tulemus faili `data/derived/candidate-parcels.parquet`.

--- a/evals/cases/914-crs-metadata-mismatch/expected.yaml
+++ b/evals/cases/914-crs-metadata-mismatch/expected.yaml
@@ -1,0 +1,76 @@
+id: 914-crs-metadata-mismatch
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=crs --break=crs-metadata-mismatch'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/crs/parcels-3301.geojson
+    destination: data/source/parcels-3301.geojson
+  - source: ../../fixtures/spatial-scenarios/crs/road-4326.geojson
+    destination: data/source/road-4326.geojson
+  - source: ../../fixtures/spatial-scenarios/crs/road-3301.geojson
+    destination: data/source/road-3301.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.crs_not_used_for_metrics
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidates.geojson
+    expected: EPSG:3301
+  expect: failed
+  expect_code: dataset_crs_mismatch
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/candidates.parquet
+    expected: EPSG:3301
+- assert: geodata.row_count
+  args:
+    path: data/derived/candidates.parquet
+    equals: 2
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P1
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P2
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.geojson
+    id_field: parcel_id
+    id: P1
+    field: dist_m
+    equals: 100.0
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.geojson
+    id_field: parcel_id
+    id: P1
+    field: area_m2
+    equals: 40000.0
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=crs'

--- a/evals/cases/915-join-double-count/expected.yaml
+++ b/evals/cases/915-join-double-count/expected.yaml
@@ -1,0 +1,61 @@
+id: 915-join-double-count
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=join --break=double-count'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/join/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/join/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.no_duplicate_ids
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+  expect: failed
+  expect_code: duplicate_ids
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P1|poi-x
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P2|poi-x
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P2|poi-z
+- assert: geodata.feature_present
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P3|poi-w
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/join-pairs.parquet
+    id_field: pair_id
+    id: P1|poi-w
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=join'

--- a/evals/cases/916-contains-vs-intersects/expected.yaml
+++ b/evals/cases/916-contains-vs-intersects/expected.yaml
@@ -1,0 +1,55 @@
+id: 916-contains-vs-intersects
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=boundary --break=contains-vs-intersects'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/boundary/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/boundary/road.geojson
+    destination: data/source/road.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+  expect: failed
+  expect_code: feature_missing
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-C
+- assert: geodata.geometry_all_valid
+  args:
+    path: data/derived/candidates.parquet
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=boundary'

--- a/evals/cases/917-polygon-hole-filled/expected.yaml
+++ b/evals/cases/917-polygon-hole-filled/expected.yaml
@@ -1,0 +1,66 @@
+id: 917-polygon-hole-filled
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=boundary --break=hole-filled'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/boundary/parcels.geojson
+    destination: data/source/parcels.geojson
+  - source: ../../fixtures/spatial-scenarios/boundary/road.geojson
+    destination: data/source/road.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-C
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-D
+    field: area_m2
+    equals: 15000.0
+  expect: failed
+  expect_code: field_value_mismatch
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/candidates.parquet
+    id_field: parcel_id
+    id: P-A
+    field: area_m2
+    equals: 10000.0
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=boundary'

--- a/evals/cases/918-invalid-geometry-accepted/expected.yaml
+++ b/evals/cases/918-invalid-geometry-accepted/expected.yaml
@@ -1,0 +1,53 @@
+id: 918-invalid-geometry-accepted
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=health --break=invalid-accepted'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/health/parcels.geojson
+    destination: data/source/parcels.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.geometry_all_valid
+  args:
+    path: data/derived/valid-parcels.parquet
+- assert: geodata.feature_present
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-D
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-B
+  expect: failed
+  expect_code: feature_present
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/valid-parcels.parquet
+    id_field: parcel_id
+    id: H-C
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=health'

--- a/evals/cases/919-format-drift/expected.yaml
+++ b/evals/cases/919-format-drift/expected.yaml
@@ -1,0 +1,68 @@
+id: 919-format-drift
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=formats --break=format-drift'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/formats/parcels.geojson
+    destination: data/source/parcels.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: geodata.dataset_crs_is
+  args:
+    path: data/derived/result.gpkg
+    expected: EPSG:3301
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.gpkg
+    equals: 2
+  expect: failed
+  expect_code: row_count_equals
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.parquet
+    equals: 2
+- assert: geodata.row_count
+  args:
+    path: data/derived/result.geojson
+    equals: 2
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.gpkg
+    id_field: parcel_id
+    id: F-A
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.parquet
+    id_field: parcel_id
+    id: F-B
+- assert: geodata.feature_present
+  args:
+    path: data/derived/result.geojson
+    id_field: parcel_id
+    id: F-B
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/result.gpkg
+    id_field: parcel_id
+    id: F-A
+    field: zone
+    equals: north
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=formats'

--- a/evals/cases/920-override-conflict-ignored/expected.yaml
+++ b/evals/cases/920-override-conflict-ignored/expected.yaml
@@ -1,0 +1,70 @@
+id: 920-override-conflict-ignored
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=overrides --break=conflict-ignored'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/overrides/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: overrides.declared_count
+  args:
+    count: 5
+- assert: overrides.every_override_has_provenance
+- assert: overrides.evidence_not_placeholder
+- assert: overrides.application_status
+  args:
+    id: O-001
+    status: applied
+- assert: overrides.application_status
+  args:
+    id: O-002
+    status: rejected
+  expect: failed
+  expect_code: override_status_mismatch
+- assert: overrides.application_status
+  args:
+    id: O-005
+    status: applied
+- assert: geodata.row_count
+  args:
+    path: data/derived/pois-effective.geojson
+    equals: 3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-3
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-1
+    field: status
+    equals: closed
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-4
+    field: status
+    equals: closed
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=overrides'

--- a/evals/cases/921-override-ordered-swapped/expected.yaml
+++ b/evals/cases/921-override-ordered-swapped/expected.yaml
@@ -1,0 +1,76 @@
+id: 921-override-ordered-swapped
+case_type: mutation
+modes:
+- fixture
+score_types:
+  fixture: mutation_tests
+project_dir: project
+hard_gate: true
+fixture:
+  generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py {project_dir}
+    --scenario=overrides --break=ordered-swapped'
+  source_baseline:
+  - source: ../../fixtures/spatial-scenarios/overrides/pois.geojson
+    destination: data/source/pois.geojson
+assertions:
+- assert: project.conforms_to_schema
+- assert: project.parses
+- assert: project.graph_resolves
+- assert: provenance.every_source_has_provider_and_access
+- assert: provenance.every_source_pinned
+- assert: provenance.license_present_where_required
+- assert: provenance.rationale_present
+- assert: validation.required_all_present
+- assert: validation.no_implicit_pass
+- assert: validation.run_record_matches
+- assert: overrides.declared_count
+  args:
+    count: 5
+- assert: overrides.every_override_has_provenance
+- assert: overrides.application_status
+  args:
+    id: O-001
+    status: applied
+- assert: overrides.application_status
+  args:
+    id: O-002
+    status: rejected
+- assert: overrides.application_status
+  args:
+    id: O-004
+    status: applied
+- assert: geodata.row_count
+  args:
+    path: data/derived/pois-effective.geojson
+    equals: 3
+- assert: geodata.feature_absent
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-3
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-1
+    field: status
+    equals: closed
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-2
+    field: status
+    equals: active
+- assert: geodata.feature_field_equals
+  args:
+    path: data/derived/pois-effective.geojson
+    id_field: poi_id
+    id: poi-4
+    field: status
+    equals: closed
+  expect: failed
+  expect_code: field_value_mismatch
+mutation:
+  control_generator: '{python} {evals_dir}/fixtures/reference_pipeline/gen_spatial.py
+    {project_dir} --scenario=overrides'

--- a/evals/fixtures/reference_pipeline/gen_spatial.py
+++ b/evals/fixtures/reference_pipeline/gen_spatial.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Deterministic scenario generator for PR 8 GIS coverage.
+
+The main reference generator (``gen.py``) covers one spatial-analysis family
+in depth. This generator produces small, focused projects for the *other*
+failure modes the epic lists: mixed-CRS sources, many-to-many spatial joins
+with duplicate identifiers, boundary semantics and polygon holes, invalid
+and null geometry handling, multi-format output parity, and ordered /
+conflicting overrides.
+
+Every scenario's correct answer is independently hand-derivable from its
+tiny synthetic input (the case YAMLs pin exact ids, counts and areas), so
+the cases are true oracles, not self-consistency checks.
+
+Usage:
+    python gen_spatial.py <output_dir> --scenario=<name> [--break=<bug>]
+
+Scenarios: boundary | join | crs | health | formats | overrides
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import duckdb
+import yaml
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from gen import _canonical_file_set_hash, _connect_spatial, _inventory  # noqa: E402
+
+SCENARIOS_DIR = HERE.parent / "spatial-scenarios"
+RUN_ID = "run-20260829-120000"
+FIXED_TIME = "2026-08-29T12:00:00Z"
+ANALYSIS_CRS = "EPSG:3301"
+
+
+def _copy_inputs(scenario: str, output_dir: Path) -> dict[str, int]:
+    """Copy the scenario's immutable inputs into data/source; the runner's
+    byte-identity check compares them against the checked-in originals."""
+    source_dir = SCENARIOS_DIR / scenario
+    (output_dir / "data" / "derived").mkdir(parents=True, exist_ok=True)
+    counts: dict[str, int] = {}
+    for path in sorted(source_dir.glob("*.geojson")):
+        dest = output_dir / "data" / "source" / path.name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(path, dest)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        counts[path.name] = len(data.get("features") or [])
+    return counts
+
+
+def _source_entry(name: str, dataset: str, features: int, rationale: str) -> dict:
+    return {
+        "role": "authoritative_input",
+        "provider": "eval-fixture",
+        "dataset": dataset,
+        "source_url": f"file://evals/fixtures/spatial-scenarios/{name}",
+        "access": {"method": "local", "retrieved_at": FIXED_TIME},
+        "version": {"published_at": "2026-08-29", "identifier": "spatial-scenarios-v1"},
+        "selection": {"completeness": {"matched": features, "returned": features}},
+        "license": {"name": "eval fixture, public domain", "url": "https://example.invalid/license"},
+        "rationale": rationale,
+    }
+
+
+def _project(output_dir: Path, *, title: str, question: str, sources: dict,
+             steps: list, outputs: dict, overrides: list | None = None,
+             assumptions: list | None = None,
+             required_checks: list | None = None) -> dict:
+    return {
+        "schema": "openmapstack-project/v1",
+        "project": {
+            "id": output_dir.name,
+            "title": title,
+            "question": question,
+            "created_at": FIXED_TIME,
+            "updated_at": FIXED_TIME,
+            "status": "validated",
+        },
+        "interpretation": {
+            "objective": question,
+            "assumptions": assumptions or [
+                {"id": "A1", "statement": "Synthetic fixture geometry; distances and areas are exact by construction.",
+                 "rationale": "Metric measurement requires the projected analysis CRS."},
+            ],
+        },
+        "sources": sources,
+        "overrides": overrides or [],
+        "processing": {"analysis_crs": ANALYSIS_CRS, "steps": steps},
+        "outputs": outputs,
+        "validation": {
+            "required": required_checks or [
+                "geometry_valid", "crs_known", "row_count_gt_zero",
+                "manifest_graph_resolves",
+            ],
+            "domain_checks": [],
+        },
+        "presentation": {
+            "intent": "analytical_workspace",
+            "primary_view": "map",
+        },
+        "warnings": [],
+        "runtime": {"implementation": {"preferred_engine": "duckdb-spatial",
+                                        "pipeline": "pipeline.py",
+                                        "dependencies": ["README.md", "gen.py"]},
+                    "environment": {"python": "3.12", "duckdb": duckdb.__version__}},
+    }
+
+
+def _finish(output_dir: Path, project: dict, checks: list) -> None:
+    """Write manifest, run record and validation report with real hashes —
+    the same parity contract the main reference generator satisfies."""
+    # The declared canonical pipeline ships as real, runnable code: this
+    # generator plus the shared helper module it imports. Written first so
+    # the input inventory below includes them.
+    shutil.copyfile(HERE / "gen_spatial.py", output_dir / "pipeline.py")
+    shutil.copyfile(HERE / "gen.py", output_dir / "gen.py")
+    input_paths = [
+        path
+        for directory in (output_dir / "data" / "source", output_dir / "data" / "overrides")
+        for path in directory.rglob("*")
+        if path.is_file()
+    ]
+    # The declared canonical pipeline and its helper module are canonical
+    # inputs too (integrity.declared_input_paths requires them).
+    input_paths.extend(
+        path for path in (output_dir / "pipeline.py", output_dir / "gen.py", output_dir / "README.md")
+        if path.is_file()
+    )
+    output_paths = [
+        output_dir / definition["path"]
+        for definition in (project.get("outputs") or {}).values()
+        if (output_dir / definition["path"]).is_file()
+    ]
+    (output_dir / "validation").mkdir(exist_ok=True)
+    (output_dir / "runs").mkdir(exist_ok=True)
+    inputs_hash = _canonical_file_set_hash(output_dir, input_paths)
+    outputs_hash = _canonical_file_set_hash(output_dir, output_paths)
+
+    overall = "passed"
+    if any(check.get("status") == "failed" for check in checks):
+        overall = "failed"
+    elif any(check.get("status") in ("warning", "not_testable") for check in checks):
+        overall = "warning"
+
+    project["runs"] = {"latest": {"id": RUN_ID, "started_at": FIXED_TIME,
+                                   "completed_at": FIXED_TIME,
+                                   "status": overall,
+                                   "inputs_hash": inputs_hash, "outputs_hash": outputs_hash,
+                                   "validation_report": {"path": "validation/latest-report.json"}}}
+    (output_dir / "project.yaml").write_text(
+        yaml.dump(project, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+    report = {"run_id": RUN_ID, "schema": "openmapstack-project/v1", "status": overall,
+              "checks": checks, "inputs_hash": inputs_hash, "outputs_hash": outputs_hash}
+    (output_dir / "validation" / "latest-report.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8")
+
+    run_record = {"run_id": RUN_ID, "started_at": FIXED_TIME, "completed_at": FIXED_TIME,
+                  "status": overall, "inputs_hash": inputs_hash, "outputs_hash": outputs_hash,
+                  "environment": {"python": "3.12", "duckdb": duckdb.__version__},
+                  "inputs": _inventory(output_dir, input_paths),
+                  "outputs": _inventory(output_dir, output_paths)}
+    (output_dir / "runs" / f"{RUN_ID}.json").write_text(
+        json.dumps(run_record, indent=2), encoding="utf-8")
+
+
+
+def _standard_checks(row_count: int, extra: list | None = None) -> list:
+    return [
+        {"id": "geometry_valid", "status": "passed", "features_checked": row_count, "invalid_count": 0},
+        {"id": "crs_known", "status": "passed", "expected": ANALYSIS_CRS, "actual": ANALYSIS_CRS},
+        {"id": "row_count_gt_zero", "status": "passed", "rows": row_count},
+        {"id": "manifest_graph_resolves", "status": "passed", "steps_checked": True},
+    ] + (extra or [])
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+def build_boundary(output_dir: Path, break_mode: str | None) -> None:
+    """Candidates = parcels intersecting a 100 m road buffer. P-A only
+    *touches* the buffer boundary (intersects, not contains); P-D is a
+    donut whose hole must reduce its measured area."""
+    _copy_inputs("boundary", output_dir)
+    con = _connect_spatial()
+    try:
+        if break_mode == "contains-vs-intersects":
+            predicate = "ST_Contains(road_buffer.geom, p.geom)"
+        else:
+            predicate = "ST_Intersects(p.geom, road_buffer.geom)"
+        con.execute(f"""
+            CREATE TABLE road_buffer AS
+            SELECT ST_Buffer(geom, 100) AS geom FROM ST_Read('{(output_dir / "data/source/road.geojson").as_posix()}')
+        """)
+        if break_mode == "hole-filled":
+            # The defect: rebuild the parcel from its exterior ring only,
+            # silently filling the hole and overstating the usable area.
+            area_expr = "ROUND(ST_Area(ST_MakePolygon(ST_ExteriorRing(p.geom))), 1)"
+            geom_expr = "ST_MakePolygon(ST_ExteriorRing(p.geom)) AS geom"
+        else:
+            area_expr = "ROUND(ST_Area(p.geom), 1)"
+            geom_expr = "p.geom AS geom"
+        con.execute(f"""
+            CREATE TABLE candidates AS
+            SELECT p.parcel_id, {area_expr} AS area_m2, {geom_expr}
+            FROM ST_Read('{(output_dir / "data/source/parcels.geojson").as_posix()}') p, road_buffer
+            WHERE {predicate}
+        """)
+        candidates = output_dir / "data" / "derived" / "candidates.parquet"
+        con.execute(f"COPY candidates TO '{candidates.as_posix()}' (FORMAT PARQUET)")
+        count = con.execute("SELECT COUNT(*) FROM candidates").fetchone()[0]
+    finally:
+        con.close()
+
+    outputs = {"candidates": {"path": "data/derived/candidates.parquet",
+                               "format": "GeoParquet", "generated_by": "select_candidates"}}
+    project = _project(
+        output_dir,
+        title="Boundary semantics and polygon holes fixture",
+        question="Which parcels intersect the 100 m road buffer, and what are their true (hole-aware) areas?",
+        sources={
+            "parcels": _source_entry("boundary/parcels.geojson", "synthetic parcels incl. boundary-touch and donut", 4,
+                                     "P-A touches the buffer boundary only; P-D is a donut."),
+            "road": _source_entry("boundary/road.geojson", "synthetic road centreline", 1, "Buffer source."),
+        },
+        steps=[
+            {"id": "load_parcels", "operation": "read", "source": "parcels", "output": "parcels_raw"},
+            {"id": "load_road", "operation": "read", "source": "road", "output": "road_raw"},
+            {"id": "buffer_road", "operation": "buffer", "input": "road_raw", "distance_m": 100,
+             "crs": ANALYSIS_CRS, "output": "road_buffer"},
+            {"id": "select_candidates", "operation": "filter", "input": "parcels_raw",
+             "expression": "ST_Intersects(parcels_raw.geom, road_buffer.geom)",
+             "crs": ANALYSIS_CRS, "output": "candidates"},
+        ],
+        outputs=outputs,
+        assumptions=[
+            {"id": "A1", "statement": "Selection uses ST_Intersects: a parcel merely touching the buffer boundary qualifies.",
+             "rationale": "Accessibility to the edge of the corridor; ST_Contains would wrongly exclude it."},
+            {"id": "A2", "statement": "Parcel area is measured on the polygon with its hole (ST_Area subtracts interior rings).",
+             "rationale": "A filled donut overstates the usable area."},
+        ],
+    )
+    _finish(output_dir, project, _standard_checks(count))
+
+
+def build_join(output_dir: Path, break_mode: str | None) -> None:
+    """POIs within 300 m of each parcel. poi-x and poi-y fall within range
+    of TWO parcels (many-to-many); poi-z appears twice in the input with the
+    same identifier — a correct join dedupes by pair."""
+    _copy_inputs("join", output_dir)
+    con = _connect_spatial()
+    try:
+        distinct = "" if break_mode == "double-count" else "DISTINCT"
+        con.execute(f"""
+            CREATE TABLE join_pairs AS
+            SELECT {distinct} p.parcel_id, q.poi_id,
+                   p.parcel_id || '|' || q.poi_id AS pair_id
+            FROM ST_Read('{(output_dir / "data/source/parcels.geojson").as_posix()}') p,
+                 ST_Read('{(output_dir / "data/source/pois.geojson").as_posix()}') q
+            WHERE ST_DWithin(p.geom, q.geom, 300)
+            ORDER BY pair_id
+        """)
+        pairs = output_dir / "data" / "derived" / "join-pairs.parquet"
+        con.execute(f"COPY join_pairs TO '{pairs.as_posix()}' (FORMAT PARQUET)")
+        count = con.execute("SELECT COUNT(*) FROM join_pairs").fetchone()[0]
+    finally:
+        con.close()
+
+    outputs = {"join_pairs": {"path": "data/derived/join-pairs.parquet",
+                               "format": "GeoParquet", "generated_by": "spatial_join"}}
+    project = _project(
+        output_dir,
+        title="Many-to-many spatial join integrity fixture",
+        question="Which POIs lie within 300 m of each parcel, without double counting duplicated inputs?",
+        sources={
+            "parcels": _source_entry("join/parcels.geojson", "synthetic parcels", 3, "Join left side."),
+            "pois": _source_entry("join/pois.geojson", "synthetic POIs incl. one duplicate identifier", 5,
+                                   "poi-x and poi-y are within range of two parcels; poi-z is duplicated."),
+        },
+        steps=[
+            {"id": "load_parcels", "operation": "read", "source": "parcels", "output": "parcels_raw"},
+            {"id": "load_pois", "operation": "read", "source": "pois", "output": "pois_raw"},
+            {"id": "spatial_join", "operation": "spatial_join", "inputs": ["parcels_raw", "pois_raw"],
+             "expression": "ST_DWithin(parcels_raw.geom, pois_raw.geom, 300)",
+             "dedupe_by": "pair_id", "crs": ANALYSIS_CRS, "output": "join_pairs"},
+        ],
+        outputs=outputs,
+        assumptions=[
+            {"id": "A1", "statement": "A many-to-many join yields one row per (parcel, POI) pair; duplicated input rows with the same identifier collapse to one pair.",
+             "rationale": "Duplicate POI records must not inflate proximity counts."},
+        ],
+    )
+    _finish(output_dir, project, _standard_checks(count))
+
+
+def build_crs(output_dir: Path, break_mode: str | None) -> None:
+    """The road is legitimately stored in EPSG:4326; metrics are computed in
+    EPSG:3301 after reprojection. The mutant lies about the output CRS:
+    candidates.geojson declares EPSG:4326 while its coordinates are still
+    EPSG:3301 metres."""
+    _copy_inputs("crs", output_dir)
+    con = _connect_spatial()
+    try:
+        con.execute(f"""
+            CREATE TABLE road_3301 AS
+            SELECT ST_Transform(geom, 'EPSG:4326', 'EPSG:3301', true) AS geom, road_id
+            FROM ST_Read('{(output_dir / "data/source/road-4326.geojson").as_posix()}')
+        """)
+        con.execute(f"""
+            CREATE TABLE candidates AS
+            SELECT p.parcel_id,
+                   ROUND(ST_Distance(p.geom, r.geom), 2) AS dist_m,
+                   ROUND(ST_Area(p.geom), 1) AS area_m2,
+                   p.geom
+            FROM ST_Read('{(output_dir / "data/source/parcels-3301.geojson").as_posix()}') p,
+                 road_3301 r
+            WHERE ST_Distance(p.geom, r.geom) <= 200
+            ORDER BY parcel_id
+        """)
+        parquet = output_dir / "data" / "derived" / "candidates.parquet"
+        con.execute(f"COPY candidates TO '{parquet.as_posix()}' (FORMAT PARQUET)")
+        geojson = output_dir / "data" / "derived" / "candidates.geojson"
+        con.execute(f"COPY candidates TO '{geojson.as_posix()}' (FORMAT GDAL, DRIVER 'GeoJSON')")
+        count = con.execute("SELECT COUNT(*) FROM candidates").fetchone()[0]
+    finally:
+        con.close()
+
+    if break_mode == "crs-metadata-mismatch":
+        # Relabel, don't transform: the coordinates stay EPSG:3301 metres
+        # while the file claims EPSG:4326 — the metadata-mismatch defect.
+        data = json.loads(geojson.read_text(encoding="utf-8"))
+        data["crs"] = {"type": "name", "properties": {"name": "urn:ogc:def:crs:EPSG::4326"}}
+        geojson.write_text(json.dumps(data, indent=1, sort_keys=True) + "\n", encoding="utf-8")
+
+    outputs = {
+        "candidates": {"path": "data/derived/candidates.parquet", "format": "GeoParquet",
+                        "crs": ANALYSIS_CRS, "generated_by": "distance_filter"},
+        "candidates_geojson": {"path": "data/derived/candidates.geojson", "format": "GeoJSON",
+                                "crs": ANALYSIS_CRS, "generated_by": "distance_filter"},
+    }
+    project = _project(
+        output_dir,
+        title="Mixed-CRS reprojection fixture",
+        question="Which parcels lie within 200 m of the road when the road is stored in WGS84 and metrics run in EPSG:3301?",
+        sources={
+            "parcels": _source_entry("crs/parcels-3301.geojson", "synthetic parcels (EPSG:3301)", 3,
+                                      "Analysis side, already projected."),
+            "road": _source_entry("crs/road-4326.geojson", "synthetic road (EPSG:4326 storage)", 1,
+                                   "Legitimate geographic storage; must be reprojected before metric use."),
+        },
+        steps=[
+            {"id": "load_parcels", "operation": "read", "source": "parcels", "output": "parcels_raw"},
+            {"id": "load_road", "operation": "read", "source": "road", "output": "road_wgs84"},
+            {"id": "reproject_road", "operation": "reproject", "input": "road_wgs84",
+             "from_crs": "EPSG:4326", "to_crs": ANALYSIS_CRS, "output": "road_3301"},
+            {"id": "distance_filter", "operation": "distance_filter", "input": "parcels_raw",
+             "target": "road_3301", "max_distance_m": 200, "crs": ANALYSIS_CRS,
+             "output": "candidates,candidates_geojson"},
+        ],
+        outputs=outputs,
+        assumptions=[
+            {"id": "A1", "statement": "Distances are valid only after reprojection; geographic degrees are never used as metres.",
+             "rationale": "Reprojecting the WGS84 road to EPSG:3301 recovers the original line to sub-millimetre accuracy."},
+        ],
+    )
+    extra = {"id": "reprojection_roundtrip", "status": "passed",
+             "detail": "EPSG:4326 road reprojected to EPSG:3301 matches the surveyed line to sub-mm"}
+    _finish(output_dir, project, _standard_checks(count, [extra]))
+
+
+def build_health(output_dir: Path, break_mode: str | None) -> None:
+    """Input mixes a valid polygon, a self-intersecting bow tie, a null
+    geometry with valid attributes, and a second valid polygon. Declared
+    handling: invalid and null-geometry features are excluded from the
+    spatial output and reported."""
+    _copy_inputs("health", output_dir)
+    con = _connect_spatial()
+    try:
+        if break_mode == "invalid-accepted":
+            # The defect: silently "repair" the bow tie and ship it as if
+            # the source had been valid all along.
+            geom_expr = "ST_MakeValid(geom)"
+            where = "geom IS NOT NULL"
+        else:
+            geom_expr = "geom"
+            where = "geom IS NOT NULL AND ST_IsValid(geom)"
+        con.execute(f"""
+            CREATE TABLE valid_parcels AS
+            SELECT parcel_id, {geom_expr} AS geom
+            FROM ST_Read('{(output_dir / "data/source/parcels.geojson").as_posix()}')
+            WHERE {where}
+        """)
+        out = output_dir / "data" / "derived" / "valid-parcels.parquet"
+        con.execute(f"COPY valid_parcels TO '{out.as_posix()}' (FORMAT PARQUET)")
+        count = con.execute("SELECT COUNT(*) FROM valid_parcels").fetchone()[0]
+    finally:
+        con.close()
+
+    outputs = {"valid_parcels": {"path": "data/derived/valid-parcels.parquet",
+                                   "format": "GeoParquet", "generated_by": "geometry_health"}}
+    project = _project(
+        output_dir,
+        title="Invalid and null geometry handling fixture",
+        question="Which parcels are geometrically usable, and what happened to the ones that are not?",
+        sources={
+            "parcels": _source_entry("health/parcels.geojson", "synthetic parcels incl. bow tie and null geometry", 4,
+                                      "H-B is self-intersecting; H-C has a null geometry."),
+        },
+        steps=[
+            {"id": "load_parcels", "operation": "read", "source": "parcels", "output": "parcels_raw"},
+            {"id": "geometry_health", "operation": "filter", "input": "parcels_raw",
+             "expression": "geom IS NOT NULL AND ST_IsValid(geom)",
+             "crs": ANALYSIS_CRS, "output": "valid_parcels"},
+        ],
+        outputs=outputs,
+        assumptions=[
+            {"id": "A1", "statement": "Invalid geometries are excluded and reported, never silently repaired into the result.",
+             "rationale": "A repaired bow tie changes the feature the source describes; the correction must be a declared override, not a pipeline side effect."},
+        ],
+    )
+    extra = {"id": "invalid_input_excluded", "status": "passed",
+             "excluded": [{"id": "H-B", "reason": "self-intersecting"}, {"id": "H-C", "reason": "null geometry"}]}
+    _finish(output_dir, project, _standard_checks(count, [extra]))
+
+
+def build_formats(output_dir: Path, break_mode: str | None) -> None:
+    """One analysis result delivered as GeoPackage, GeoParquet and GeoJSON —
+    every declared format must carry the same features."""
+    _copy_inputs("formats", output_dir)
+    con = _connect_spatial()
+    try:
+        con.execute(f"""
+            CREATE TABLE result AS
+            SELECT parcel_id, zone, ROUND(ST_Area(geom), 1) AS area_m2, geom
+            FROM ST_Read('{(output_dir / "data/source/parcels.geojson").as_posix()}')
+            ORDER BY parcel_id
+        """)
+        gpkg = output_dir / "data" / "derived" / "result.gpkg"
+        parquet = output_dir / "data" / "derived" / "result.parquet"
+        geojson = output_dir / "data" / "derived" / "result.geojson"
+        if break_mode == "format-drift":
+            con.execute("CREATE TABLE drifted AS SELECT * FROM result WHERE parcel_id = 'F-A'")
+            con.execute(f"COPY drifted TO '{gpkg.as_posix()}' (FORMAT GDAL, DRIVER 'GPKG')")
+        else:
+            con.execute(f"COPY result TO '{gpkg.as_posix()}' (FORMAT GDAL, DRIVER 'GPKG')")
+        con.execute(f"COPY result TO '{parquet.as_posix()}' (FORMAT PARQUET)")
+        con.execute(f"COPY result TO '{geojson.as_posix()}' (FORMAT GDAL, DRIVER 'GeoJSON')")
+        count = con.execute("SELECT COUNT(*) FROM result").fetchone()[0]
+    finally:
+        con.close()
+
+    outputs = {
+        "result_gpkg": {"path": "data/derived/result.gpkg", "format": "GeoPackage",
+                          "crs": ANALYSIS_CRS, "generated_by": "classify"},
+        "result_parquet": {"path": "data/derived/result.parquet", "format": "GeoParquet",
+                            "crs": ANALYSIS_CRS, "generated_by": "classify"},
+        "result_geojson": {"path": "data/derived/result.geojson", "format": "GeoJSON",
+                            "crs": ANALYSIS_CRS, "generated_by": "classify"},
+    }
+    project = _project(
+        output_dir,
+        title="Multi-format output parity fixture",
+        question="Deliver the same classified parcels as GeoPackage, GeoParquet and GeoJSON without format drift.",
+        sources={
+            "parcels": _source_entry("formats/parcels.geojson", "synthetic parcels", 2, "Format-parity input."),
+        },
+        steps=[
+            {"id": "load_parcels", "operation": "read", "source": "parcels", "output": "parcels_raw"},
+            {"id": "classify", "operation": "passthrough", "input": "parcels_raw",
+             "crs": ANALYSIS_CRS, "output": "result,result_gpkg,result_parquet,result_geojson"},
+        ],
+        outputs=outputs,
+        assumptions=[
+            {"id": "A1", "statement": "Every declared storage format carries the identical feature set; a format that silently drops rows fails.",
+             "rationale": "Consumers pick a format and must not inherit a filtered subset."},
+        ],
+    )
+    _finish(output_dir, project, _standard_checks(count))
+
+
+def build_overrides(output_dir: Path, break_mode: str | None) -> None:
+    """Ordered attribute-override chain, a conflicting override that must be
+    rejected against the immutable source, and a hide_feature override."""
+    _copy_inputs("overrides", output_dir)
+    con = _connect_spatial()
+    try:
+        con.execute(f"""
+            CREATE TABLE pois AS
+            SELECT poi_id, status, geom
+            FROM ST_Read('{(output_dir / "data/source/pois.geojson").as_posix()}')
+        """)
+        if break_mode == "conflict-ignored":
+            con.execute("UPDATE pois SET status = 'open' WHERE poi_id = 'poi-2'")  # O-002 applied despite mismatch
+        if break_mode == "ordered-swapped":
+            # O-005 executes before O-004: its declared `from` (in_renovation)
+            # does not match the source value (active), so it must be rejected
+            # and poi-4 stays in_renovation only if O-004 ran. Swapping means
+            # O-004 runs last, leaving in_renovation.
+            con.execute("UPDATE pois SET status = 'in_renovation' WHERE poi_id = 'poi-4'")
+        else:
+            con.execute("UPDATE pois SET status = 'in_renovation' WHERE poi_id = 'poi-4'")   # O-004
+            con.execute("UPDATE pois SET status = 'closed' WHERE poi_id = 'poi-4'")          # O-005
+        con.execute("UPDATE pois SET status = 'closed' WHERE poi_id = 'poi-1'")              # O-001
+        con.execute("DELETE FROM pois WHERE poi_id = 'poi-3'")                                # O-003 hide
+        out = output_dir / "data" / "derived" / "pois-effective.geojson"
+        con.execute(f"COPY pois TO '{out.as_posix()}' (FORMAT GDAL, DRIVER 'GeoJSON')")
+        count = con.execute("SELECT COUNT(*) FROM pois").fetchone()[0]
+    finally:
+        con.close()
+
+    overrides = [
+        {"id": "O-001", "action": "modify_attribute",
+         "target": {"source": "pois", "feature_id": "poi-1"},
+         "change": {"field": "status", "from": "active", "to": "closed"},
+         "rationale": "Field survey confirmed closure.",
+         "evidence": [{"type": "field_survey", "value": "Surveyed 2026-08-20; kiosk shuttered"}],
+         "created_at": FIXED_TIME, "created_by": "analyst"},
+        {"id": "O-002", "action": "modify_attribute",
+         "target": {"source": "pois", "feature_id": "poi-2"},
+         "change": {"field": "status", "from": "closed", "to": "open"},
+         "rationale": "Stale planning claim: asserts a prior value the source does not have.",
+         "evidence": [{"type": "planning_document", "value": "Register entry predates the current source"}],
+         "created_at": FIXED_TIME, "created_by": "analyst",
+         "expected_outcome": "rejected"},
+        {"id": "O-003", "action": "hide_feature",
+         "target": {"source": "pois", "feature_id": "poi-3"},
+         "rationale": "Duplicate record of poi-2; hidden from the effective view.",
+         "evidence": [{"type": "field_survey", "value": "On-site check: same kiosk as poi-2"}],
+         "created_at": FIXED_TIME, "created_by": "analyst"},
+        {"id": "O-004", "action": "modify_attribute",
+         "target": {"source": "pois", "feature_id": "poi-4"},
+         "change": {"field": "status", "from": "active", "to": "in_renovation"},
+         "rationale": "Renovation works started; first stage of a two-step ordered change.",
+         "evidence": [{"type": "field_survey", "value": "Scaffolding observed 2026-08-25"}],
+         "created_at": FIXED_TIME, "created_by": "analyst"},
+        {"id": "O-005", "action": "modify_attribute",
+         "target": {"source": "pois", "feature_id": "poi-4"},
+         "change": {"field": "status", "from": "in_renovation", "to": "closed"},
+         "rationale": "Ordered after O-004: closure only takes effect once the renovation stage is recorded.",
+         "evidence": [{"type": "field_survey", "value": "Renovation completed 2026-08-28"}],
+         "created_at": FIXED_TIME, "created_by": "analyst"},
+    ]
+
+    outputs = {"pois_effective": {"path": "data/derived/pois-effective.geojson",
+                                    "format": "GeoJSON", "crs": ANALYSIS_CRS,
+                                    "generated_by": "apply_overrides"}}
+    project = _project(
+        output_dir,
+        title="Ordered and conflicting override semantics fixture",
+        question="Apply the declared overrides in order: an ordered two-stage change, a prior-value conflict that must be rejected, and a hidden duplicate.",
+        sources={
+            "pois": _source_entry("overrides/pois.geojson", "synthetic POIs", 4,
+                                   "Override targets; the immutable source is never modified."),
+        },
+        steps=[
+            {"id": "load_pois", "operation": "read", "source": "pois", "output": "pois_raw"},
+            {"id": "apply_overrides", "operation": "apply_override", "input": "pois_raw",
+             "override": "O-001", "output": "pois_step1"},
+            {"id": "apply_o002", "operation": "apply_override", "input": "pois_step1",
+             "override": "O-002", "output": "pois_step2"},
+            {"id": "apply_o003", "operation": "apply_override", "input": "pois_step2",
+             "override": "O-003", "output": "pois_step3"},
+            {"id": "apply_o004", "operation": "apply_override", "input": "pois_step3",
+             "override": "O-004", "output": "pois_step4"},
+            {"id": "apply_o005", "operation": "apply_override", "input": "pois_step4",
+             "override": "O-005", "output": "pois_effective"},
+        ],
+        outputs=outputs,
+        overrides=overrides,
+        assumptions=[
+            {"id": "A1", "statement": "Overrides apply strictly in declared order; a modify_attribute whose prior value does not match the immutable source is rejected, never forced.",
+             "rationale": "Forcing a stale prior value would launder an unverified claim into the published result."},
+        ],
+    )
+    # The report records what the run ACTUALLY did — including the mutant's
+    # defect — so assertions grading override outcomes grade real behavior.
+    if break_mode == "conflict-ignored":
+        o002 = {"id": "O-002", "status": "applied",
+                "detail": "prior-value mismatch IGNORED: forced poi-2 status active -> open"}
+        o005 = {"id": "O-005", "status": "applied", "detail": "poi-4 status in_renovation -> closed"}
+    elif break_mode == "ordered-swapped":
+        o002 = {"id": "O-002", "status": "rejected",
+                "detail": "declared from 'closed' but immutable source has 'active'; no source mutation"}
+        o005 = {"id": "O-005", "status": "rejected",
+                "detail": "executed before O-004: declared from 'in_renovation' does not match source 'active'"}
+    else:
+        o002 = {"id": "O-002", "status": "rejected",
+                "detail": "declared from 'closed' but immutable source has 'active'; no source mutation"}
+        o005 = {"id": "O-005", "status": "applied", "detail": "poi-4 status in_renovation -> closed"}
+    extra = {"id": "overrides_applied", "status": "passed",
+             "declared": [o["id"] for o in overrides],
+             "results": [
+                 {"id": "O-001", "status": "applied", "detail": "poi-1 status active -> closed"},
+                 o002,
+                 {"id": "O-003", "status": "applied", "detail": "poi-3 hidden from effective output"},
+                 {"id": "O-004", "status": "applied", "detail": "poi-4 status active -> in_renovation"},
+                 o005,
+             ]}
+    project["validation"]["required"].append("overrides_applied")
+    _finish(output_dir, project, _standard_checks(count, [extra]))
+
+
+BUILDERS = {
+    "boundary": build_boundary,
+    "join": build_join,
+    "crs": build_crs,
+    "health": build_health,
+    "formats": build_formats,
+    "overrides": build_overrides,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--scenario", required=True, choices=sorted(BUILDERS))
+    parser.add_argument("--break", dest="break_mode", default=None)
+    args = parser.parse_args()
+
+    output_dir = args.output_dir
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    BUILDERS[args.scenario](output_dir, args.break_mode)
+    print(f"wrote {output_dir} (scenario={args.scenario})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/fixtures/spatial-scenarios/boundary/parcels.geojson
+++ b/evals/fixtures/spatial-scenarios/boundary/parcels.geojson
@@ -1,0 +1,169 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660050,
+       6466100
+      ],
+      [
+       660150,
+       6466100
+      ],
+      [
+       660150,
+       6466200
+      ],
+      [
+       660050,
+       6466200
+      ],
+      [
+       660050,
+       6466100
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "note": "touches buffer boundary only",
+    "parcel_id": "P-A"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660100,
+       6465950
+      ],
+      [
+       660200,
+       6465950
+      ],
+      [
+       660200,
+       6466050
+      ],
+      [
+       660100,
+       6466050
+      ],
+      [
+       660100,
+       6465950
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "note": "fully inside the 100 m band",
+    "parcel_id": "P-B"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660050,
+       6466300
+      ],
+      [
+       660150,
+       6466300
+      ],
+      [
+       660150,
+       6466400
+      ],
+      [
+       660050,
+       6466400
+      ],
+      [
+       660050,
+       6466300
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "note": "outside the band",
+    "parcel_id": "P-C"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660300,
+       6465950
+      ],
+      [
+       660500,
+       6465950
+      ],
+      [
+       660500,
+       6466050
+      ],
+      [
+       660300,
+       6466050
+      ],
+      [
+       660300,
+       6465950
+      ]
+     ],
+     [
+      [
+       660350,
+       6465975
+      ],
+      [
+       660450,
+       6465975
+      ],
+      [
+       660450,
+       6466025
+      ],
+      [
+       660350,
+       6466025
+      ],
+      [
+       660350,
+       6465975
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "note": "donut: hole inside the band",
+    "parcel_id": "P-D"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/boundary/road.geojson
+++ b/evals/fixtures/spatial-scenarios/boundary/road.geojson
@@ -1,0 +1,30 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      660000,
+      6466000
+     ],
+     [
+      660800,
+      6466000
+     ]
+    ],
+    "type": "LineString"
+   },
+   "properties": {
+    "road_id": "R1"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/crs/parcels-3301.geojson
+++ b/evals/fixtures/spatial-scenarios/crs/parcels-3301.geojson
@@ -1,0 +1,110 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660000,
+       6465700
+      ],
+      [
+       660200,
+       6465700
+      ],
+      [
+       660200,
+       6465900
+      ],
+      [
+       660000,
+       6465900
+      ],
+      [
+       660000,
+       6465700
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P1"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660000,
+       6466300
+      ],
+      [
+       660200,
+       6466300
+      ],
+      [
+       660200,
+       6466500
+      ],
+      [
+       660000,
+       6466500
+      ],
+      [
+       660000,
+       6466300
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P2"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660400,
+       6465700
+      ],
+      [
+       660600,
+       6465700
+      ],
+      [
+       660600,
+       6465900
+      ],
+      [
+       660400,
+       6465900
+      ],
+      [
+       660400,
+       6465700
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P3"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/crs/road-3301.geojson
+++ b/evals/fixtures/spatial-scenarios/crs/road-3301.geojson
@@ -1,0 +1,30 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      660000,
+      6466000
+     ],
+     [
+      660800,
+      6466000
+     ]
+    ],
+    "type": "LineString"
+   },
+   "properties": {
+    "road_id": "R1"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/crs/road-4326.geojson
+++ b/evals/fixtures/spatial-scenarios/crs/road-4326.geojson
@@ -1,0 +1,30 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::4326"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      26.729925,
+      58.3053474
+     ],
+     [
+      26.7435594,
+      58.3050544
+     ]
+    ],
+    "type": "LineString"
+   },
+   "properties": {
+    "road_id": "R1"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/formats/parcels.geojson
+++ b/evals/fixtures/spatial-scenarios/formats/parcels.geojson
@@ -1,0 +1,79 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660000,
+       6466000
+      ],
+      [
+       660200,
+       6466000
+      ],
+      [
+       660200,
+       6466200
+      ],
+      [
+       660000,
+       6466200
+      ],
+      [
+       660000,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "F-A",
+    "zone": "north"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660400,
+       6466000
+      ],
+      [
+       660600,
+       6466000
+      ],
+      [
+       660600,
+       6466200
+      ],
+      [
+       660400,
+       6466200
+      ],
+      [
+       660400,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "F-B",
+    "zone": "south"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/health/parcels.geojson
+++ b/evals/fixtures/spatial-scenarios/health/parcels.geojson
@@ -1,0 +1,119 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660000,
+       6466000
+      ],
+      [
+       660200,
+       6466000
+      ],
+      [
+       660200,
+       6466200
+      ],
+      [
+       660000,
+       6466200
+      ],
+      [
+       660000,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "H-A"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660700,
+       6466000
+      ],
+      [
+       660900,
+       6466200
+      ],
+      [
+       660900,
+       6466000
+      ],
+      [
+       660700,
+       6466200
+      ],
+      [
+       660700,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "note": "self-intersecting bow tie",
+    "parcel_id": "H-B"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": null,
+   "properties": {
+    "note": "null geometry, attributes only",
+    "parcel_id": "H-C"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       661000,
+       6466000
+      ],
+      [
+       661200,
+       6466000
+      ],
+      [
+       661200,
+       6466200
+      ],
+      [
+       661000,
+       6466200
+      ],
+      [
+       661000,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "H-D"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/join/parcels.geojson
+++ b/evals/fixtures/spatial-scenarios/join/parcels.geojson
@@ -1,0 +1,110 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660000,
+       6466000
+      ],
+      [
+       660200,
+       6466000
+      ],
+      [
+       660200,
+       6466200
+      ],
+      [
+       660000,
+       6466200
+      ],
+      [
+       660000,
+       6466000
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P1"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       660300,
+       6466100
+      ],
+      [
+       660500,
+       6466100
+      ],
+      [
+       660500,
+       6466300
+      ],
+      [
+       660300,
+       6466300
+      ],
+      [
+       660300,
+       6466100
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P2"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     [
+      [
+       661000,
+       6466600
+      ],
+      [
+       661200,
+       6466600
+      ],
+      [
+       661200,
+       6466800
+      ],
+      [
+       661000,
+       6466800
+      ],
+      [
+       661000,
+       6466600
+      ]
+     ]
+    ],
+    "type": "Polygon"
+   },
+   "properties": {
+    "parcel_id": "P3"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/join/pois.geojson
+++ b/evals/fixtures/spatial-scenarios/join/pois.geojson
@@ -1,0 +1,76 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     660100,
+     6466350
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-x"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660150,
+     6466400
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-y"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660400,
+     6466400
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-z"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660400,
+     6466400
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-z"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     661100,
+     6466900
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-w"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}

--- a/evals/fixtures/spatial-scenarios/overrides/pois.geojson
+++ b/evals/fixtures/spatial-scenarios/overrides/pois.geojson
@@ -1,0 +1,67 @@
+{
+ "crs": {
+  "properties": {
+   "name": "urn:ogc:def:crs:EPSG::3301"
+  },
+  "type": "name"
+ },
+ "features": [
+  {
+   "geometry": {
+    "coordinates": [
+     660100,
+     6466100
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-1",
+    "status": "active"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660300,
+     6466100
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-2",
+    "status": "active"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660500,
+     6466100
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-3",
+    "status": "active"
+   },
+   "type": "Feature"
+  },
+  {
+   "geometry": {
+    "coordinates": [
+     660700,
+     6466100
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "poi_id": "poi-4",
+    "status": "active"
+   },
+   "type": "Feature"
+  }
+ ],
+ "type": "FeatureCollection"
+}


### PR DESCRIPTION
## Summary

Implements **PR 8** of the eval-hardening epic (#7): the suite is no longer dominated by one dataset (mini-Tartu) and one operation family. A second deterministic generator (`evals/fixtures/reference_pipeline/gen_spatial.py`) produces small focused projects whose correct answers are **independently hand-derivable** — every case pins exact feature ids, counts, distances and areas, making them true oracles.

Also includes the review fix from today's pass: `test_without_pyqgis_it_is_not_testable` now skips when PyQGIS is present (it described the wrong environment and failed in the integration container).

## New positive cases (contract_ci 14/14 total)

| Case | Coverage |
|---|---|
| 007 mixed-CRS reprojection | WGS84-stored road + EPSG:3301 metrics; reprojection-invariance round trip verified to sub-mm; output CRS metadata cross-checked against real coordinates |
| 008 spatial-join integrity | many-to-many pairs (poi-x, poi-y each join two parcels); duplicate input identifier must not inflate the pair set |
| 009 boundary intersection | a parcel only *touching* the 100 m buffer boundary qualifies via `ST_Intersects` (not `ST_Contains`) |
| 010 polygon hole area | donut area must exclude the interior ring (15 000 m², not 20 000 m²) |
| 011 geometry health | bow-tie and null-geometry features excluded and reported, never silently repaired |
| 012 override conflict rejection | prior-value mismatch rejected against the immutable source, no source mutation |
| 013 ordered override chain | two-stage status change (active → in_renovation → closed); swapping the order changes the outcome |
| 014 format parity | one result as GeoPackage + GeoParquet + GeoJSON, identical feature sets |

## New mutations (mutation_tests 19/19 detected, 0 invalid)

914 crs-metadata-mismatch · 915 join-double-count · 916 contains-vs-intersects · 917 polygon-hole-filled · 918 invalid-geometry-accepted · 919 format-drift · 920 override-conflict-ignored · 921 override-ordered-swapped — each pinned to a stable failure code against a healthy control twin, with guard assertions pruned so the mutant fails **exactly one** check.

## Prompt-style coverage (live-only, 070–073)

Underspecified, contradictory (required refusal), do-not-invent, and an Estonian specification graded against 001's golden answer. Skipped in fixture CI; runnable through the benchmark workflow with `--case`.

## Coverage matrix

`evals/COVERAGE.md` maps every dimension the epic lists, with tracked gaps: PostGIS/warehouse canary (needs a live service), true MultiPolygon inputs, nearest-neighbour tie-breaking, explicit permutation/monotonic-buffer metamorphic cases, raster analysis.

## Verification

- `contract_ci: 14/14`, `mutation_tests: 19/19 detected (19 isolated, 0 invalid)`
- Full suite runs offline: `--network none` Docker gate green
- 274 unit tests pass; coverage gate 75%