### PR TITLE
docs: add agent-neutral maintainer knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Read only what is relevant to the current issue.
 | Canonical worked integration example | `examples/tartu-development/` |
 | CLI, schema handling, reusable checks | `openmapstack/` |
 | Eval architecture, cases, scoring, live adapters | `evals/README.md`, `evals/` |
+| Maintainer architecture/rationale/debugging knowledge | `docs/maintainers/` |
 | Implementation tests | `tests/` |
 | User-facing install and usage docs | `README.md` |
 
@@ -53,13 +54,31 @@ For a new issue or increment:
 
 1. Read this file, the issue/task, and `git status`/the current diff.
 2. Locate the owning module and its tests; inspect only the relevant files first.
-3. Read `SKILL.md` or detailed references only if the change affects shipped skill behavior.
-4. Make the smallest coherent change that resolves the issue; avoid unrelated refactors.
-5. Add or update the appropriate test/eval evidence.
-6. Run the narrowest relevant checks, then broader checks when the change warrants them.
-7. Update README/reference docs only when their public contract or usage has changed.
+3. Read `docs/maintainers/` only when architecture, rationale, recurring traps, or prior decisions could materially affect the task.
+4. Read `SKILL.md` or detailed references only if the change affects shipped skill behavior.
+5. Make the smallest coherent change that resolves the issue; avoid unrelated refactors.
+6. Add or update the appropriate test/eval evidence.
+7. Run the narrowest relevant checks, then broader checks when the change warrants them.
+8. Update README/reference docs only when their public contract or usage has changed.
 
-Do not recursively read the whole repository to "understand the project" before working. Do not rely on prior chat/session memory for durable project facts; encode important decisions in code, tests, eval cases, or the appropriate documentation.
+Do not recursively read the whole repository to "understand the project" before working.
+
+## Durable project knowledge
+
+Tool-specific memory (Claude/Gemini auto-memory, Pi/Codex session history, IDE agent state, etc.) is a convenience cache, not a source of truth.
+
+When work reveals a non-obvious fact that will matter across future sessions or tools, promote it to the repository **only when rediscovery would be materially expensive or error-prone**:
+
+- repository-wide workflow/routing rule -> `AGENTS.md`;
+- cross-cutting architecture or invariant -> `docs/maintainers/architecture.md`;
+- recurring hard-to-rediscover diagnostic trap -> `docs/maintainers/debugging.md`;
+- consequential architectural choice and rationale -> `docs/maintainers/decisions/`;
+- behavioral guarantee -> owning code plus tests/evals;
+- product/skill behavior -> `SKILL.md` or the owning `references/` document.
+
+Do not persist facts that are obvious from the code, cheap to rediscover, specific to one transient session, or already owned by another contract. Do not let a tool-specific private memory become the sole record of a project invariant.
+
+When editing `docs/maintainers/`, follow its nested `AGENTS.md`: keep those notes concise, provider-neutral, linked to owning sources, and free of duplicated roadmaps/specifications.
 
 ## Skill-development rules
 
@@ -119,4 +138,5 @@ There is currently no repository-wide linter command configured in `pyproject.to
 - When changing an eval assertion, prove both the healthy/control path and the intended failure path where applicable.
 - `not_testable` is not `passed`; do not turn missing capability into green evidence.
 - Keep README and public docs synchronized with externally visible behavior, not with internal implementation trivia.
+- Promote durable, non-obvious maintenance knowledge according to the policy above; do not rely on chat/session memory as the only record.
 - Do not claim a task is complete until the relevant checks have actually run, or explicitly report what could not be run and why.

--- a/docs/maintainers/AGENTS.md
+++ b/docs/maintainers/AGENTS.md
@@ -1,0 +1,42 @@
+# Maintainer knowledge editing rules
+
+These instructions apply when adding or changing files under `docs/maintainers/`.
+
+The goal is to preserve durable cross-agent knowledge without creating a second, stale specification of the repository.
+
+## Before adding a note
+
+Ask:
+
+- Is this fact non-obvious from code/tests and expensive to rediscover?
+- Will it plausibly matter after the current issue/session ends?
+- Is there already a more authoritative place for it?
+- Can the durable lesson be encoded as a test/eval instead of prose?
+
+If the answer points to code, a test, an eval, an issue, `SKILL.md`, `references/`, or `docs/verify-applicability.md`, update that owner first. Add a maintainer note only for context, rationale, cross-cutting navigation, or a recurring trap that the owner cannot express well by itself.
+
+## Writing rules
+
+- Keep notes provider- and coding-agent-neutral unless documenting an explicit adapter/integration surface.
+- Link to owning files and GitHub issues instead of copying long specifications or roadmaps.
+- Separate accepted architecture from temporary known debt.
+- Date temporary sections and state the issue/condition that should remove them.
+- Do not record secrets, local absolute paths, credentials, private session URLs, model transcripts, or ephemeral benchmark output.
+- Do not add generated inventories of functions/files; agents can inspect the repository.
+- Prefer a small number of maintained documents over one file per incident.
+
+## Promotion from tool-specific memory
+
+Claude/Gemini/Pi/Codex/Copilot session or auto-memory may contain useful discoveries, but it is only a convenience cache. Promote a discovery when it meets the durability test above:
+
+- workflow/routing rule -> root `AGENTS.md`;
+- cross-cutting architecture/invariant -> `architecture.md`;
+- recurring diagnostic trap -> `debugging.md`;
+- consequential choice with alternatives/rationale -> `decisions/`;
+- behavioral guarantee -> owning code plus tests/evals.
+
+Never make a tool-specific memory the sole record of a project invariant.
+
+## Review discipline
+
+When modifying these files, check that referenced code/issue state is still current. Delete or rewrite stale notes rather than accumulating historical layers. Significant architectural changes should update the relevant note in the same PR.

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -1,0 +1,46 @@
+# Maintainer knowledge
+
+This directory holds durable, cross-agent knowledge for people and coding agents maintaining the OpenMapStack codebase.
+
+It is **not** part of the shipped geospatial skill. `SKILL.md`, `references/`, and `templates/` describe the product consumed by agents in other projects; this directory describes how this repository is engineered, why important boundaries exist, and which hard-earned maintenance facts should not need to be rediscovered in every fresh session.
+
+## What belongs here
+
+Promote a discovery here when all of these are true:
+
+1. it is non-obvious from the owning code or tests;
+2. it is likely to matter in a future issue or fresh agent session;
+3. rediscovering it would be materially expensive or error-prone; and
+4. it can be stated without duplicating a more authoritative contract.
+
+Prefer the narrowest durable home:
+
+- `architecture.md` — subsystem boundaries, evidence flows, invariants, and ownership seams;
+- `debugging.md` — recurring failure modes, environment traps, and diagnostic routes;
+- `decisions/` — significant choices where the rationale and rejected alternatives matter later;
+- owning code/tests/evals — executable behavior and guarantees;
+- root `AGENTS.md` — repository-wide workflow/routing rules that should be seen on every cold start.
+
+Do not use this directory as a diary, issue backlog, generated code map, or substitute for tests. File locations, function inventories, one-off failures, model-specific observations, and facts cheap to rediscover with `rg`, tests, or Git normally do not belong here.
+
+## Source-of-truth rule
+
+These notes are navigation and rationale, not a competing specification. When a statement here conflicts with an executable contract or owning document, fix this note rather than treating it as authoritative.
+
+Important existing owners include:
+
+- shipped skill behavior: `SKILL.md` and `references/`;
+- `openmapstack-project/v1`: `references/project-spec.md` plus `openmapstack/schemas/project-v1.schema.json` and validators;
+- automatic verification applicability: `docs/verify-applicability.md`;
+- eval execution/scoring: `evals/README.md`, eval schemas, runner, cases, and tests;
+- current planned work: GitHub issues, especially the active epics rather than copied roadmap prose here.
+
+## Keeping the area useful
+
+- Date temporary/current-state notes and link the issue that will make them obsolete.
+- Remove resolved debugging notes once the underlying trap is fully encoded by tests and no longer needs human context.
+- Prefer links to exact owning files/issues over pasted copies of their content.
+- Record *why* a boundary exists, not merely *what files exist*.
+- When a real-world or live-agent failure escapes the current checks, first preserve the failure as a regression test/eval where practical; the prose note is secondary.
+
+See `AGENTS.md` in this directory for instructions that apply when editing these knowledge files.

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -1,0 +1,168 @@
+# Maintainer architecture notes
+
+This document records cross-cutting architecture that is easy to misread from one subsystem in isolation. It is deliberately shorter than the product/reference documentation and should not duplicate contracts owned elsewhere.
+
+## Repository purpose and layers
+
+OpenMapStack is a **managed agent-skill product plus its executable QA/support code**.
+
+```text
+Shipped guidance/product
+  SKILL.md
+  references/
+  templates/
+  examples/
+  distribution compatibility (.claude-plugin/, agents/)
+            |
+            v
+Produced openmapstack-project/v1 artifacts
+            |
+     +------+-------------------+
+     |                          |
+     v                          v
+openmapstack package          evals/
+validate / verify / rerun     fixture/live/visual harness
+shared semantic checks <------+
+     |
+     v
+user/project evidence
+```
+
+The distinction matters: `SKILL.md` is the product being developed and evaluated. It is not the maintainer bootstrap for this repository.
+
+### Source-of-truth boundaries
+
+- Agent-facing behavior: `SKILL.md` and the relevant file in `references/`.
+- Project contract: `references/project-spec.md`; machine validation is also constrained by `openmapstack/schemas/project-v1.schema.json` and `openmapstack/validation.py`.
+- Automatic `verify` plan and applicability: `docs/verify-applicability.md` plus `openmapstack/verify.py`.
+- Eval semantics: `evals/README.md`, `evals/schemas/`, `evals/run.py`, case definitions, and tests.
+- Roadmap/current work: GitHub issues. Do not mirror their checklists here.
+
+When these disagree, resolve the inconsistency at the owning layer rather than adding another interpretation here.
+
+## Three evidence questions must stay separate
+
+The current architecture intentionally answers three different questions with related machinery but different denominators:
+
+1. **Regression/contract CI** — can deterministic checks recognize compliant fixtures and isolated defects?
+2. **Project QA** — does a particular produced project satisfy the checks that are applicable and executable in the current environment?
+3. **Agent/model benchmark** — can an agent/model configuration produce a good project from a controlled task?
+
+Issue #13 is the current roadmap owner for this separation. Do not collapse these into one quality score: a green fixture suite, a user project's `verify` report, and a live agent pass rate are different evidence.
+
+## `validate` and `verify` intentionally do different work
+
+`openmapstack validate` is the contract/bookkeeping layer. `openmapstack/validation.py` validates schema/metadata, interpretation, provenance, override declarations, processing/output declarations, presentation, runtime, validation declarations, and—when artifact checks are enabled—the produced files, validation report, and run record.
+
+`openmapstack verify` is evidence-oriented project QA. It builds a plan from the manifest rather than letting the project opt out of checks, then invokes reusable checks against the actual artifacts. Examples include geometry validity, artifact CRS, provenance, validation/run-record consistency, presentation/QGIS consistency, attested expectations, and optionally a clean rerun.
+
+Consequences:
+
+- `validate --preflight` is not a substitute for full artifact health; it deliberately skips checks that require produced artifacts.
+- `verify` does not claim to prove every project-specific analytical answer. It proves bounded structural/provenance/artifact/reproducibility predicates and exposes what it could not test.
+- New user-facing correctness checks should normally be reusable from `openmapstack/checks/`, not hidden only inside eval scaffolding.
+
+## Shared semantic check library
+
+`openmapstack/checks/` is deliberately shipped with the package and shared by two callers:
+
+- `evals/run.py`, for deterministic and live benchmark grading;
+- `openmapstack verify`, for a user's own project.
+
+Checks return `AssertionResult` with one of four states:
+
+- `passed`
+- `failed`
+- `warning`
+- `not_testable`
+
+Expected inability to establish a predicate must not raise or silently pass. Missing dependencies, unsupported artifact formats, or absent addressing information normally become `not_testable` with a stable code where useful.
+
+Most checks are oracle-free. The small set that requires a known project-specific answer is not automatically trusted on user data; it is reachable through `validation.expectations[]` and the attestation machinery in `openmapstack/expectations.py`.
+
+## Attested project-specific expectations
+
+A pipeline cannot certify its own golden answer. For known-answer checks, an expectation is executed only after independent evidence is bound to:
+
+- the exact check and arguments (`expectation_sha256`);
+- the current project input hash;
+- reviewer/source metadata and evidence digest.
+
+Unverified, incomplete, changed, or input-stale attestations are visible as warnings and their expected value is not executed as trusted evidence. The allowlist is intentionally narrow.
+
+This is a trust boundary: do not expand the expectation surface by exposing arbitrary check functions or executable arguments without equivalent safety and provenance constraints.
+
+## Clean rerun is a project-state boundary
+
+`openmapstack/rerun.py` owns the clean-rerun protocol used by both `verify --rerun` and evals. There must not be a second eval-only implementation.
+
+The rerun workspace preserves only the project manifest, conventional immutable inputs (`data/source/`, `data/overrides/`), the canonical implementation, and explicitly declared dependencies. It then:
+
+1. rejects unsafe/escaping paths and symlinked preserved dependency trees;
+2. resolves one canonical command/pipeline;
+3. strips conversation/provider-related environment state and `PYTHONPATH`;
+4. executes without a shell;
+5. verifies immutable-source hashes did not change;
+6. runs full artifact validation on the rebuilt project;
+7. records machine-readable rerun evidence.
+
+The eval harness additionally forbids reaching back into eval reference generators. That restriction is supplied by the eval caller; the shipped package intentionally does not know that `evals/` exists.
+
+## Integrity and path safety
+
+Project-relative paths are resolved through `openmapstack/project.py` helpers and must remain under the project root. Code that adds new file addressing should reuse the same safety model rather than joining unchecked user paths.
+
+Run/input integrity uses path-aware SHA-256 inventories (`openmapstack/integrity.py`): the relative file name participates in the canonical set hash, not only concatenated bytes. Immutable input inventory includes source/override files plus canonical implementation/dependencies; the manifest itself is excluded from the input hash because it records the resulting digest.
+
+Be careful with resolved vs unresolved roots: temporary/macOS paths can include symlinked prefixes (`/var` vs `/private/var`). Existing helpers resolve roots before `relative_to()` comparisons for this reason.
+
+## Eval architecture
+
+`evals/run.py` has three execution modes and four score types:
+
+- `fixture` -> deterministic `contract_ci` or `mutation_tests`;
+- `live` -> `agent_benchmark` through an explicit adapter;
+- `visual` -> `integration_visual` for positive cases or `mutation_tests` for visual mutations.
+
+Important invariants:
+
+- fixture mode is the safe default and does not call an agent;
+- malformed configuration, zero executed cases, generator/adapter/runtime failure are **setup failures** (exit 2), not scored failures;
+- mutation cases require a healthy control and an isolated target failure; unrelated breakage must not satisfy the mutation;
+- live results normalize provider-specific execution into `openmapstack-agent-run/v1`; raw vendor events remain audit evidence rather than scoring semantics;
+- final assistant prose is retained for audit but correctness comes from produced artifacts and deterministic checks.
+
+The live adapters (`claude_code`, `codex`, `openai_compatible`) are compatibility surfaces. Their model IDs, environment variables, event formats, and quirks must not leak into shared project/check schemas.
+
+## CI/runtime split
+
+The repository deliberately uses different environments for different evidence:
+
+- `.github/workflows/evals.yml` — ordinary PR/push deterministic fixture/unit coverage, including an offline `--network none` fixture gate;
+- `.github/workflows/eval-benchmark.yml` — scheduled/manual live agent benchmark, non-blocking for ordinary PRs;
+- `.github/workflows/eval-visual.yml` — scheduled/manual QGIS + browser integration in a QGIS container;
+- `.github/workflows/plugin.yml` — Claude Code plugin-manifest compatibility only; it is not the generic project CI contract.
+
+Do not make ordinary deterministic CI depend on live model credentials or mutable external services merely to increase apparent coverage.
+
+## QGIS and web presentation are views, not analytical state
+
+The canonical analysis remains the project manifest/pipeline/artifacts. QGIS and web products are views over the same declared data and presentation semantics.
+
+Two established QGIS traps have dedicated checks because a project may load successfully while displaying a confidently wrong map:
+
+- hand-written QGIS XML must declare each layer's CRS, including Web-Mercator basemaps;
+- web map layer order and QGIS layer-tree paint order are opposite, so naïvely copying manifest order can hide layers.
+
+Runtime/rendered validation supplements structural validation. It does not turn visual plausibility into analytical correctness.
+
+## Active architecture seams
+
+These are intentionally linked rather than restated as roadmap:
+
+- issue #13 — project QA, metamorphic checks, source pinning, and OpenMapBench interoperability;
+- issue #11 — optional QGIS generation/edit round-trip evolution;
+- issue #6 — standard dashboard renderer and presentation-to-render validation;
+- `evals/COVERAGE.md` — explicit current GIS coverage gaps.
+
+When one of these changes a durable boundary above, update this document in the same PR.

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -22,7 +22,7 @@ Produced openmapstack-project/v1 artifacts
      v                          v
 openmapstack package          evals/
 validate / verify / rerun     fixture/live/visual harness
-shared semantic checks <------+
+shared semantic checks <------+ 
      |
      v
 user/project evidence
@@ -100,11 +100,13 @@ The rerun workspace preserves only the project manifest, conventional immutable 
 
 1. rejects unsafe/escaping paths and symlinked preserved dependency trees;
 2. resolves one canonical command/pipeline;
-3. strips conversation/provider-related environment state and `PYTHONPATH`;
+3. strips `PYTHONPATH` and environment variables whose names match the current conversation/provider blacklist (`ANTHROPIC`, `CHAT`, `CLAUDE`, `CODEX`, `CONVERSATION`, `OPENAI`, `PROMPT`, `TRANSCRIPT`);
 4. executes without a shell;
 5. verifies immutable-source hashes did not change;
 6. runs full artifact validation on the rebuilt project;
 7. records machine-readable rerun evidence.
+
+This environment cleanup is deliberately **not** a general sandbox or allowlist today. Variables such as `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and arbitrary service/configuration variables can still survive unless separately removed. Therefore a clean rerun proves independence from the excluded workspace artifacts and the known blacklisted session/provider variables; it does not yet prove independence from all undeclared ambient environment state. A future allowlisted environment would provide the stronger guarantee.
 
 The eval harness additionally forbids reaching back into eval reference generators. That restriction is supplied by the eval caller; the shipped package intentionally does not know that `evals/` exists.
 
@@ -138,12 +140,12 @@ The live adapters (`claude_code`, `codex`, `openai_compatible`) are compatibilit
 
 The repository deliberately uses different environments for different evidence:
 
-- `.github/workflows/evals.yml` — ordinary PR/push deterministic fixture/unit coverage, including an offline `--network none` fixture gate;
+- `.github/workflows/evals.yml` — ordinary PR/push deterministic unit + fixture CI; its unit-test stage installs Playwright/Chromium, and the same workflow later runs a separate Docker fixture gate with runtime networking disabled;
 - `.github/workflows/eval-benchmark.yml` — scheduled/manual live agent benchmark, non-blocking for ordinary PRs;
 - `.github/workflows/eval-visual.yml` — scheduled/manual QGIS + browser integration in a QGIS container;
 - `.github/workflows/plugin.yml` — Claude Code plugin-manifest compatibility only; it is not the generic project CI contract.
 
-Do not make ordinary deterministic CI depend on live model credentials or mutable external services merely to increase apparent coverage.
+Do not conflate ordinary fixture CI with the narrower offline Docker gate. Do not make deterministic project/eval correctness depend on live model credentials or mutable external services merely to increase apparent coverage.
 
 ## QGIS and web presentation are views, not analytical state
 

--- a/docs/maintainers/debugging.md
+++ b/docs/maintainers/debugging.md
@@ -1,0 +1,120 @@
+# Maintainer debugging notes
+
+These are recurring, non-obvious traps observed in the current architecture. Prefer fixing the root cause and adding regression coverage; keep a note only when the diagnostic context is still useful across issues and tools.
+
+## Start by identifying the evidence layer
+
+A failure often looks contradictory because different commands answer different questions.
+
+- `openmapstack validate` — manifest/bookkeeping and, without `--preflight`, produced-artifact/report/run-record consistency.
+- `openmapstack verify` — reusable evidence checks against real artifacts; may report `not_testable` when the environment cannot establish a predicate.
+- `python evals/run.py --mode fixture` — deterministic reference/mutation suite.
+- `python evals/run.py --mode visual` — QGIS/browser integration in a capable environment.
+- `python evals/run.py --mode live ...` — stochastic agent execution; setup/agent failures are not assertion results.
+
+Before changing a checker because one layer is green and another red, confirm whether both were expected to inspect the same property.
+
+## `--preflight` can hide a broken worked example
+
+`openmapstack validate ... --preflight` deliberately skips checks that need produced artifacts, validation reports, and run records. It is useful before a project has run; it is not full health evidence.
+
+**Current temporary debt (2026-09-02):** issue #14 tracks that `examples/tartu-development` fails its own full verification because of a stale run-record inventory and manifest/QGIS layer-group drift, while ordinary CI currently smoke-tests it with `--preflight`. Remove/update this note when #14 is resolved and protected by the appropriate CI path.
+
+Useful comparison:
+
+```bash
+openmapstack validate examples/tartu-development/project.yaml --preflight
+openmapstack validate examples/tartu-development/project.yaml
+openmapstack verify examples/tartu-development/project.yaml
+```
+
+## `not_testable` is evidence, not success
+
+A check that cannot establish its predicate must not become a pass. Typical causes include:
+
+- DuckDB Spatial unavailable or unable to read an artifact;
+- no EPSG code/addressing for a CRS cross-check;
+- PyQGIS unavailable for runtime QGIS checks;
+- missing report/run evidence required by a checker.
+
+`verify` reports applicability/execution coverage. A mixture of executed checks and `not_testable` checks aggregates to `warning`, not `passed`; if nothing applicable can execute, the result is `not_testable`.
+
+When adding a check, include an unavailable-dependency path in tests where relevant. Catching an exception and returning `passed` is a regression; uncaught expected environmental failure is also wrong.
+
+## DuckDB geometry columns are not always named `geom`
+
+The fixture generator historically wrote `geom`, which hid a real-world bug: GeoPandas/GeoParquet commonly use `geometry`. The shipped geodata checks now resolve a typed GEOMETRY column first and then conventional names.
+
+Do not reintroduce hardcoded `geom` assumptions in new generic checks. A checker intended for user projects should discover the geometry column or require explicit safe addressing.
+
+## QGIS can be valid and still show the wrong map
+
+Two failures have already escaped simpler validity checks:
+
+1. **Missing layer CRS in hand-written `.qgs` XML.** A Web-Mercator basemap with no `<srs>` may be interpreted in the project CRS and render ~1500 km from the analysis while every datasource still looks valid. Prefer the PyQGIS API where possible; it resolves provider CRS. Static checks require declared CRS for all layers.
+2. **Layer-tree ordering.** MapLibre/web layers are conventionally declared bottom-to-top, while QGIS paints the first tree entry on top. Copying manifest order verbatim can bury point/line layers under opaque polygons. The generated QGIS tree needs the appropriate reverse paint order.
+
+A nonblank render alone is insufficient. The visual suite includes layer-removal comparison and manifest reconciliation because a rendered image can be nonblank while a declared layer is absent.
+
+## Visual mode expects its environment to be capable
+
+The scheduled visual job runs in `qgis/qgis:3.44-trixie` and installs Playwright/Chromium. Assertions scoped to visual mode are hard gates there. Missing PyQGIS/browser dependencies in an ordinary local Python environment should not be mistaken for a visual regression; use the correct container/environment or interpret the explicit `not_testable` result.
+
+Fixture CI intentionally remains browser-free/offline. Do not solve local visual dependency issues by making ordinary fixture CI depend on QGIS or network services.
+
+## DuckDB Spatial is prepared explicitly for deterministic evals
+
+Eval workflows call `evals/prepare_spatial.py` and set `OPENMAPSTACK_SPATIAL_EXTENSION_DIR` before running checks. The offline Docker gate then runs with network disabled.
+
+If fixture geodata checks suddenly try to download DuckDB Spatial at runtime, inspect the controlled extension-directory setup before weakening the offline gate.
+
+## Clean rerun intentionally removes convenient ambient state
+
+A clean rerun is meant to fail when the project only works because of the original agent session or undeclared machine state.
+
+The protocol removes conversation/provider-related environment keys and `PYTHONPATH`, rejects unsafe/escaping preserved paths and symlinked dependency trees, and executes the canonical command without a shell. It preserves only the manifest, immutable sources/overrides, canonical implementation files, and declared dependencies.
+
+If a project works in the original workspace but fails `verify --rerun`, first check whether a real runtime/config dependency is undeclared. Do not automatically copy more of the original workspace into the rerun; that can destroy the test's value.
+
+Eval clean reruns additionally forbid calling the repository's reference generator. A project that reproduces itself by rerunning the oracle has not demonstrated independent reproducibility.
+
+## Path comparisons must account for resolved roots
+
+On macOS and some temporary-directory layouts, paths such as `/var/...` resolve through `/private/var/...`. Comparing a resolved child to an unresolved root with `Path.relative_to()` can therefore fail even when the path is genuinely inside the project.
+
+Existing project/integrity code resolves the root before containment/relative comparisons. Reuse those helpers instead of recreating path-safety logic ad hoc.
+
+## Integrity hashes include path identity
+
+`canonical_file_set_hash` hashes both each sorted project-relative path and its bytes. This intentionally distinguishes inventories with identical concatenated bytes under different names.
+
+When debugging a run-record mismatch, inspect both:
+
+- which files are in the canonical input/output inventory; and
+- the bytes of those files.
+
+A renamed implementation/dependency is expected to change the canonical set hash even if file contents are unchanged.
+
+## Live evals have stricter setup semantics than ordinary scripts
+
+Live benchmark evidence is publishable only when the run identity is explicit. The runner requires an exact model identity and explicit skill arm (`enabled`/`disabled`) for live mode. Zero executed cases, missing agent CLI, adapter failure, generator failure, timeout, or malformed case configuration are setup failures (exit code 2), excluded from scored denominators.
+
+Do not convert these into assertion failures just to keep a benchmark run green; setup failure and task failure answer different questions.
+
+## Mutation tests require one isolated intended defect
+
+A mutation case is valid only when its healthy control passes and the mutation produces the pinned intended failing assertion/code while isolation guards remain healthy. An unrelated broken setup or second defect should invalidate the mutation rather than count as successful detection.
+
+When a plausible wrong project from a live/user run survives the current checks, the preferred feedback loop is:
+
+1. minimize the defect;
+2. add a healthy control and one deliberate break mode;
+3. pin the intended failure code;
+4. add checker/unit coverage if the defect exposes a checker bug;
+5. only then add prose context here if the trap remains worth remembering.
+
+## Generated benchmark artifacts are evidence, not source
+
+Retained live/visual evidence belongs under `evals/results/<run-id>/...` and CI artifacts. Do not treat generated result JSON, screenshots, event streams, or temporary projects as canonical repository state unless a fixture intentionally owns them.
+
+The normalized `agent.json` is vendor-neutral audit data; raw provider events are diagnostics. Assistant final-answer prose is never the correctness oracle.

--- a/docs/maintainers/debugging.md
+++ b/docs/maintainers/debugging.md
@@ -60,7 +60,7 @@ A nonblank render alone is insufficient. The visual suite includes layer-removal
 
 The scheduled visual job runs in `qgis/qgis:3.44-trixie` and installs Playwright/Chromium. Assertions scoped to visual mode are hard gates there. Missing PyQGIS/browser dependencies in an ordinary local Python environment should not be mistaken for a visual regression; use the correct container/environment or interpret the explicit `not_testable` result.
 
-Fixture CI intentionally remains browser-free/offline. Do not solve local visual dependency issues by making ordinary fixture CI depend on QGIS or network services.
+Ordinary `.github/workflows/evals.yml` is **not** browser-free: its unit-test stage installs Playwright/Chromium and runs browser-assertion tests. The same workflow later has a distinct Docker fixture gate that runs with runtime networking disabled. Keep those environments separate when diagnosing failures; do not solve local visual dependency issues by making deterministic fixture grading depend on QGIS, live agents, or mutable external services.
 
 ## DuckDB Spatial is prepared explicitly for deterministic evals
 
@@ -68,11 +68,13 @@ Eval workflows call `evals/prepare_spatial.py` and set `OPENMAPSTACK_SPATIAL_EXT
 
 If fixture geodata checks suddenly try to download DuckDB Spatial at runtime, inspect the controlled extension-directory setup before weakening the offline gate.
 
-## Clean rerun intentionally removes convenient ambient state
+## Clean rerun intentionally removes some convenient ambient state
 
-A clean rerun is meant to fail when the project only works because of the original agent session or undeclared machine state.
+A clean rerun is meant to fail when the project only works because of the original agent session or undeclared machine state, but the current environment sanitization is a blacklist rather than a complete sandbox.
 
-The protocol removes conversation/provider-related environment keys and `PYTHONPATH`, rejects unsafe/escaping preserved paths and symlinked dependency trees, and executes the canonical command without a shell. It preserves only the manifest, immutable sources/overrides, canonical implementation files, and declared dependencies.
+The protocol removes `PYTHONPATH` and variables whose names contain one of the current blacklist fragments: `ANTHROPIC`, `CHAT`, `CLAUDE`, `CODEX`, `CONVERSATION`, `OPENAI`, `PROMPT`, or `TRANSCRIPT`. It also rejects unsafe/escaping preserved paths and symlinked dependency trees and executes the canonical command without a shell. The rerun workspace itself preserves only the manifest, immutable sources/overrides, canonical implementation files, and declared dependencies.
+
+Do not assume this proves independence from **all** ambient environment state. Variables such as `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and arbitrary service/configuration variables can currently survive. If a project unexpectedly passes only on one machine/provider environment, inspect surviving environment dependencies as well as copied project state. Moving the rerun process to an explicit environment allowlist would provide a stronger boundary.
 
 If a project works in the original workspace but fails `verify --rerun`, first check whether a real runtime/config dependency is undeclared. Do not automatically copy more of the original workspace into the rerun; that can destroy the test's value.
 

--- a/docs/maintainers/decisions/0001-separate-evidence-tiers.md
+++ b/docs/maintainers/decisions/0001-separate-evidence-tiers.md
@@ -1,0 +1,40 @@
+# 0001 — Keep regression CI, project QA, and agent benchmarks separate
+
+- Status: Accepted
+- Date: 2026-09-02
+- Related: issue #13; `openmapstack/verify.py`; `evals/run.py`
+
+## Context
+
+The repository uses many of the same semantic checks in three settings, but a green result means something different in each:
+
+- deterministic fixtures/mutations test the contract and checkers;
+- `openmapstack verify` evaluates one produced project and exposes applicability limits;
+- live benchmarks evaluate an agent/model configuration over controlled tasks.
+
+Combining these into one pass rate or score would create false equivalence between checker regression evidence, project evidence, and model performance.
+
+## Decision
+
+Maintain separate evidence tiers and denominators. Share checker implementations where their predicates are genuinely common, but keep execution semantics, setup failures, applicability, and reporting appropriate to the question being answered.
+
+Fixture conformance, mutation detection, project verification, visual integration, and live agent success must not be collapsed into one generic quality number.
+
+## Consequences
+
+- `evals/run.py` keeps distinct score types (`contract_ci`, `mutation_tests`, `agent_benchmark`, `integration_visual`).
+- `verify` reports project-specific applicability/execution coverage rather than benchmark success rates.
+- Setup failures stay outside scored benchmark denominators.
+- Public benchmark orchestration can evolve separately from the shipped user-project verifier while reusing stable checks.
+
+This produces more report surfaces, but each number has a defensible meaning.
+
+## Alternatives considered
+
+### One unified OpenMapStack score
+
+Rejected because a score that mixes mutation detection, fixture correctness, unavailable project checks, and stochastic agent trials has no stable interpretation.
+
+### Separate checker implementations for each tier
+
+Rejected because the same semantic predicate would drift between CI, user QA, and benchmark grading. Shared checks are preferable where the predicate is actually identical.

--- a/docs/maintainers/decisions/0002-provider-neutral-core.md
+++ b/docs/maintainers/decisions/0002-provider-neutral-core.md
@@ -1,0 +1,41 @@
+# 0002 — Keep the core provider-neutral and isolate agent integrations
+
+- Status: Accepted
+- Date: 2026-09-02
+- Related: `AGENTS.md`; `evals/adapters/`; `agents/`; `.claude-plugin/`
+
+## Context
+
+OpenMapStack is intended to be consumed and maintained across multiple agents and providers. At the same time, real integrations need provider-specific CLIs, protocols, model identifiers, credentials, event formats, and packaging metadata.
+
+Allowing one provider's concepts to become the generic project/eval architecture would make the skill less portable and cause shared schemas to churn with adapter details.
+
+## Decision
+
+Keep shared skill instructions, project contracts, semantic checks, evidence schemas, and maintainer guidance provider-neutral.
+
+Provider/tool-specific behavior belongs behind explicit compatibility surfaces such as:
+
+- `evals/adapters/` for live execution;
+- `.claude-plugin/` for Claude Code distribution compatibility;
+- `agents/` for installer/agent metadata;
+- provider-specific CI workflow legs or secrets.
+
+Normalize live execution into vendor-neutral evidence (`openmapstack-agent-run/v1`) before the eval runner reasons about it. Raw provider events may be retained for audit/diagnostics but are not shared scoring semantics.
+
+## Consequences
+
+- Adding a new coding agent should normally require an adapter/compatibility layer, not changes to `openmapstack-project/v1`.
+- Model IDs, provider environment variables, and protocol quirks must not leak into generic project/check schemas.
+- Root `AGENTS.md` is the canonical maintainer bootstrap; tool-specific instruction files should remain thin compatibility shims.
+- Provider-specific support may legitimately exist and be tested without making that provider the default architecture.
+
+## Alternatives considered
+
+### Standardize on Claude Code because it has rich project memory/plugin support
+
+Rejected because repository knowledge and contracts would become inaccessible or second-class in Pi, Codex, Copilot, Gemini, and other agents.
+
+### Hide provider differences entirely behind an OpenAI-compatible API
+
+Rejected because CLI agents expose materially different tool loops, permissions, event evidence, and execution semantics. Adapter isolation is more honest than pretending the protocols are identical.

--- a/docs/maintainers/decisions/0003-shared-clean-rerun.md
+++ b/docs/maintainers/decisions/0003-shared-clean-rerun.md
@@ -1,0 +1,34 @@
+# 0003 — Use one clean-rerun protocol for evals and user verification
+
+- Status: Accepted
+- Date: 2026-09-02
+- Related: `openmapstack/rerun.py`; `openmapstack/verify.py`; `evals/run.py`; issue #13
+
+## Context
+
+Reproducibility is only meaningful if the project can rebuild itself from declared project state rather than from the original chat, eval generator, cached outputs, or undeclared workstation state.
+
+Originally this logic lived close to eval machinery. `openmapstack verify --rerun` needs the same guarantee for user projects. Maintaining two similar rerun implementations would allow benchmark evidence and user QA to drift apart.
+
+## Decision
+
+`openmapstack/rerun.py` owns the clean-rerun protocol. Both user verification and evals call it.
+
+The shared protocol preserves only declared project state, strips conversational/provider ambient state, protects immutable inputs, runs the one canonical implementation, and validates the rebuilt artifacts. Eval-specific exclusions (for example, forbidding the reference generator) are injected by the eval caller rather than hardcoded into the shipped package.
+
+## Consequences
+
+- A reproducibility fix in the shared protocol benefits both project QA and evals.
+- `openmapstack/` remains independent of the repository's eval fixture layout.
+- A project that only works because undeclared local/session state is present should fail the clean rerun instead of having more ambient state copied into the sandbox.
+- Future parameterized/metamorphic execution should extend the same declared-state model rather than create another hidden execution path.
+
+## Alternatives considered
+
+### Keep an eval-specific clean-rerun implementation
+
+Rejected because it would make the benchmark's definition of reproducibility differ from the user's verifier and would inevitably drift.
+
+### Copy the whole original project workspace and delete obvious outputs
+
+Rejected because undeclared caches, config, transcripts, generated helpers, or secrets could silently survive and make a non-reproducible project appear reproducible.

--- a/docs/maintainers/decisions/0003-shared-clean-rerun.md
+++ b/docs/maintainers/decisions/0003-shared-clean-rerun.md
@@ -14,13 +14,16 @@ Originally this logic lived close to eval machinery. `openmapstack verify --reru
 
 `openmapstack/rerun.py` owns the clean-rerun protocol. Both user verification and evals call it.
 
-The shared protocol preserves only declared project state, strips conversational/provider ambient state, protects immutable inputs, runs the one canonical implementation, and validates the rebuilt artifacts. Eval-specific exclusions (for example, forbidding the reference generator) are injected by the eval caller rather than hardcoded into the shipped package.
+The shared protocol preserves only declared project files/state, strips `PYTHONPATH` plus a defined blacklist of conversation/provider-related environment variables, protects immutable inputs, runs the one canonical implementation, and validates the rebuilt artifacts. Eval-specific exclusions (for example, forbidding the reference generator) are injected by the eval caller rather than hardcoded into the shipped package.
+
+The current environment cleanup is not an allowlist or a complete process sandbox. Environment variables outside the blacklist—including Gemini/Google credentials or arbitrary service/configuration variables—may survive. The clean-rerun guarantee must therefore be stated narrowly: it proves independence from excluded project artifacts and the environment state that is explicitly removed, not from every possible undeclared ambient variable. A future allowlisted execution environment would strengthen this boundary.
 
 ## Consequences
 
 - A reproducibility fix in the shared protocol benefits both project QA and evals.
 - `openmapstack/` remains independent of the repository's eval fixture layout.
-- A project that only works because undeclared local/session state is present should fail the clean rerun instead of having more ambient state copied into the sandbox.
+- A project that only works because excluded local/session state is present should fail the clean rerun instead of having more ambient state copied into the sandbox.
+- Surviving ambient environment variables remain a known limitation and should be considered when investigating unexpectedly environment-dependent reruns.
 - Future parameterized/metamorphic execution should extend the same declared-state model rather than create another hidden execution path.
 
 ## Alternatives considered
@@ -32,3 +35,7 @@ Rejected because it would make the benchmark's definition of reproducibility dif
 ### Copy the whole original project workspace and delete obvious outputs
 
 Rejected because undeclared caches, config, transcripts, generated helpers, or secrets could silently survive and make a non-reproducible project appear reproducible.
+
+### Start the rerun process from an explicit environment allowlist
+
+Not implemented yet. This would provide a stronger guarantee than the current blacklist and is the preferred direction if clean-rerun isolation is tightened further.

--- a/docs/maintainers/decisions/README.md
+++ b/docs/maintainers/decisions/README.md
@@ -1,0 +1,39 @@
+# Architecture decision records
+
+Use this directory for consequential choices whose rationale or rejected alternatives are likely to matter after the implementation details change.
+
+Do **not** create an ADR for routine refactors, file moves, dependency bumps, or choices already obvious from a narrow owning contract.
+
+## Status values
+
+- `Accepted` — current architecture.
+- `Superseded` — retained for rationale/history, with a link to the replacing ADR.
+- `Proposed` — under active review; do not describe it elsewhere as current architecture.
+
+## Template
+
+```markdown
+# NNNN — Short decision title
+
+- Status: Accepted | Proposed | Superseded
+- Date: YYYY-MM-DD
+- Related: issue/PR/commit links or repository paths
+
+## Context
+
+What problem or competing constraints made a decision necessary?
+
+## Decision
+
+What boundary/approach is chosen?
+
+## Consequences
+
+What becomes easier/harder? What invariants must future changes preserve?
+
+## Alternatives considered
+
+Only alternatives that were genuinely plausible and whose rejection is useful to remember.
+```
+
+When superseding a decision, update both records. The current code/tests remain authoritative for implementation details.


### PR DESCRIPTION
@jaakla — **manual review requested before merge.** I seeded this from a codebase/issue-history review rather than from generic project-memory boilerplate.

## What this adds

- `docs/maintainers/README.md` — purpose, ownership, promotion criteria, and anti-bloat rules
- `docs/maintainers/AGENTS.md` — path-scoped instructions for keeping the knowledge area useful and agent/provider neutral
- `docs/maintainers/architecture.md` — current cross-cutting architecture and trust/evidence boundaries
- `docs/maintainers/debugging.md` — recurring traps and diagnostic routes already exposed by the code/eval history
- `docs/maintainers/decisions/` — ADR convention plus three retrospective decisions that are already clearly embodied in current code/history
- root `AGENTS.md` — routes durable discoveries into the shared knowledge area and explicitly treats tool-specific memory as a disposable cache

## Review basis

I reviewed the current package/eval layout and relevant sources including:

- `openmapstack/validation.py`, `verify.py`, `rerun.py`, `expectations.py`, `integrity.py`, project/path helpers, and the shipped check library
- `evals/run.py`, adapter normalization, `evals/README.md`, `evals/COVERAGE.md`, and CI split across fixture/live/visual workflows
- recent architecture-changing commits around shared checks, clean reruns, verification, QGIS failures, and live benchmark semantics
- active issues #13, #14, #11, and #6 plus completed eval epic #7
- `docs/verify-applicability.md`

## Things I specifically want you to review

- [x] Does `architecture.md` describe the intended product-vs-maintainer boundary correctly?
- [x] Are the three retrospective ADRs decisions you want to preserve as explicit architecture, rather than leaving only in commit/issue history?
- [x] Is the temporary issue #14 note in `debugging.md` useful enough to keep until the example/CI gap is fixed?
- [x] Is the promotion threshold strict enough to prevent `docs/maintainers/` becoming an AI-generated dumping ground?
- [x] Are there any important hard-earned facts currently only in your local/Claude/Pi/Codex memory that should be promoted before merge?

## Scope

Documentation/instructions only. No `SKILL.md`, runtime, eval, schema, test, template, or example behavior is changed. No runtime tests were run because the diff contains no executable code.
