### PR TITLE
Release 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-map-stack",
   "displayName": "OpenMapStack",
   "description": "Agentic GIS / geospatial workflows: source discovery and provenance (from open data sources first), vector/raster/point-cloud pipelines, CRS and metric analysis, spatial SQL, QGIS projects, tile generation, and web maps — compiled into reproducible projects.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Jaak Laineste",
     "url": "https://github.com/jaakla"

--- a/openmapstack/__init__.py
+++ b/openmapstack/__init__.py
@@ -3,4 +3,4 @@
 from .validation import Check, ValidationResult, validate_project
 
 __all__ = ["Check", "ValidationResult", "validate_project"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openmapstack"
-version = "0.1.0"
+version = "0.2.0"
 description = "Validate, run, and inspect reproducible OpenMapStack projects"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import tomllib
+import unittest
+from pathlib import Path
+
+from openmapstack import __version__
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def test_python_and_plugin_versions_match(self) -> None:
+        package = tomllib.loads(
+            (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )["project"]["version"]
+        plugin = json.loads(
+            (REPO_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )["version"]
+
+        self.assertEqual(__version__, package)
+        self.assertEqual(plugin, package)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bump the Python package, CLI, and Claude plugin to 0.2.0
- add a regression test keeping all version surfaces synchronized

## Validation
- 317 unit tests passed
- `openmapstack --version` reports 0.2.0
- `claude plugin validate . --strict` passed
- wheel and sdist built successfully; `twine check` passed