### PR TITLE
ci(example): make the artifact-currency check advisory on pull requests

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -9,7 +9,10 @@ name: Worked example (full validation)
 #
 # It reaches three external services (Maa- ja Ruumiamet S3, the ETAK WFS, and
 # Tartu's ArcGIS Feature Services), so it is deliberately not on every PR:
-# an outage upstream must not redden unrelated work.
+# an outage upstream must not redden unrelated work. For the same reason the
+# artifact-currency check at the end is advisory on a pull request and a hard
+# failure on the schedule -- live sources drift on their own timetable, which
+# is a fact about the world rather than a defect in someone's branch.
 
 on:
   schedule:
@@ -64,11 +67,26 @@ jobs:
         # facility counts, so an upstream change to Tartu's education data
         # will trip this too -- also correctly: the committed example has then
         # stopped describing the current sources and wants regenerating.
+        #
+        # That second case is why this is advisory on a pull request. The
+        # sources are live third-party services, so a kindergarten opening in
+        # Tartu changes project.qgz without anything in the PR being wrong,
+        # and the diff would then block a merge for a fact about the world.
+        # The scheduled run is the one whose job is to notice that drift, and
+        # there it stays a hard failure. The steps above -- validate, verify,
+        # and the real-QGIS render -- are what a PR is actually gated on: they
+        # ask whether this change broke the example, not whether the example
+        # still matches sources that moved underneath it.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           git diff --exit-code -- examples/tartu-development/project.qgz || {
-            echo "::error::The committed project.qgz differs from the one pipeline.py"\
+            if [ "$EVENT_NAME" = "pull_request" ]; then level=warning; else level=error; fi
+            echo "::${level}::The committed project.qgz differs from the one pipeline.py"\
                  "just produced. Re-run examples/tartu-development/pipeline.py and"\
-                 "commit the regenerated project.qgz (and its run record)."
+                 "commit the regenerated project.qgz (and its run record). On a pull"\
+                 "request this is advisory: upstream Tartu data moves on its own."
             git diff --stat -- examples/tartu-development/project.qgz
             exit 1
           }

--- a/docs/maintainers/debugging.md
+++ b/docs/maintainers/debugging.md
@@ -122,6 +122,41 @@ Two related traps:
 - a relation's detection power depends on the data and the variant size. Widening the mini-Tartu road threshold by 1.5× cannot expose an inverted predicate because the only far parcel sits at 5450 m; the fixture declares `variant: {multiply: 3}` for that reason. When a mutation survives, check the geometry before suspecting the relation;
 - a GeoJSON output without a `crs` member reads back as EPSG:4326. A pipeline that writes analysis-CRS coordinates into plain GeoJSON and declares `EPSG:3301` in the manifest fails `geodata.dataset_crs_is` correctly. Write the `crs` member (or use GeoParquet) rather than relaxing the check.
 
+## A red worked-example job is usually the world moving, not the branch
+
+`.github/workflows/example.yml` regenerates `examples/tartu-development/` from
+live Estonian services, so its failures split into two kinds that look
+identical in the checks list:
+
+- **the change broke the example** — reported by `validate`, `verify`, or the
+  real-QGIS render step;
+- **the sources moved** — reported only by the final artifact-currency step,
+  which diffs the regenerated `project.qgz` against the committed one. The
+  legend embeds facility counts (`Verified municipal schools (n=26)`), so one
+  opening or closing in Tartu rewrites the file. It is advisory on a pull
+  request and a hard failure on the schedule for exactly this reason.
+
+To tell them apart without guessing, read the job's uploaded `worked-example-run`
+artifact rather than re-running anything: its run record inventories every
+output by SHA-256 and its validation report carries feature counts, both
+comparable with what the repository ships.
+
+```bash
+gh run download <run-id> -n worked-example-run -D /tmp/wx
+```
+
+Observed 2026-09-09 (issue #20's PR): the counts read 517 against a committed
+518, seven of the eight inventoried outputs differed, and `project.qgz`
+differed at an identical 3698 bytes — consistent with a same-length digit
+substitution in one of those legend counts.
+
+Note what that byte-identical size rules out. Comparing a `.qgz` compares a
+deflate stream, so a zlib or QGIS change could in principle move the bytes with
+the content unchanged. It was not the cause there and the container is
+deterministic by construction — `write_qgis_project` pins the zip entry to a
+1980 timestamp and fixed permissions — but a currency failure with *no*
+accompanying digest drift in the run record is the signature to suspect.
+
 ## Generated benchmark artifacts are evidence, not source
 
 Retained live/visual evidence belongs under `evals/results/<run-id>/...` and CI artifacts. Do not treat generated result JSON, screenshots, event streams, or temporary projects as canonical repository state unless a fixture intentionally owns them.


### PR DESCRIPTION
## What

The worked-example job regenerates `examples/tartu-development/` from three live Estonian services, then diffs the regenerated `project.qgz` against the committed one. That last step asks *"has the committed example stopped describing its sources?"* — a question about the world, not about a branch. Its legend embeds facility counts (`Verified municipal schools (n=26)`), so one kindergarten opening in Tartu rewrites the file and blocks an unrelated merge.

This scopes that one assertion by event: a hard failure on `schedule` / `workflow_dispatch`, advisory on `pull_request`. Nothing else changes — `validate`, `verify`, and the real-QGIS render step all still gate PRs, and they are what actually answer whether a change broke the example.

## Why now

On 2026-09-09 PR #25, which touches only the CLI, went red here. The evidence, from the job's own uploaded run record and validation report:

- upstream parcel count moved **518 → 517**;
- seven of the eight inventoried outputs differed, including `data/derived/education_pois.json`;
- `project.qgz` differed at an identical 3698 bytes — consistent with a same-length digit substitution in a legend count.

The control: the same step already failed on `main` at d4e1bd3 in the scheduled run of 2026-09-07, two days before that branch existed. The drift preceded the branch.

I checked the alternative explanation and it does not hold: extracting the committed `project.qgs` and re-zipping it with the pipeline's exact recipe reproduces the committed bytes hash-for-hash, so the zip container is deterministic and this was not a compression-encoder change.

This is the workflow's own stated intent — *"an outage upstream must not redden unrelated work"* — applied to data drift as well as to outages.

## Also

A note in `docs/maintainers/debugging.md` on telling the two failure kinds apart from the uploaded `worked-example-run` artifact, since working that out took downloading CI artifacts and diffing digests.

## Not fixed here

`main` stays red on the schedule until someone with access to the live sources reruns `examples/tartu-development/pipeline.py` and commits the regenerated `project.qgz` and run record. That is the alarm working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqoLGyKY5opHGjNMSerpHg